### PR TITLE
Refine compositor lifecycle, fault handling, and state contribution semantics

### DIFF
--- a/crates/fpa-compositor/docs/SPECIFICATION.md
+++ b/crates/fpa-compositor/docs/SPECIFICATION.md
@@ -9,7 +9,7 @@ Traces to: FPA-SRS-000, FPA-CON-000
 | FPA-006 | Shared state machine with single owner | Pending |
 | FPA-009 | Compositor runtime: lifecycle, bus, context, arbitration | Pending |
 | FPA-010 | Relay authority for inter-layer communication | Implemented |
-| FPA-011 | Fault handling with context and fallback | Pending |
+| FPA-011 | Fault handling with context and propagation | Pending |
 | FPA-012 | Recursive state contribution | Implemented |
 | FPA-013 | Direct signals bypass relay chain | Implemented |
 | FPA-014 | Double-buffered tick lifecycle | Pending |

--- a/crates/fpa-compositor/src/compositor.rs
+++ b/crates/fpa-compositor/src/compositor.rs
@@ -10,7 +10,6 @@ use fpa_bus::{Bus, BusExt, BusReader, DeferredBus, InProcessBus, TypedReader};
 use fpa_contract::{DumpRequest, LoadRequest, Partition, PartitionError, StateContribution};
 use fpa_events::EventEngine;
 
-// Re-export SharedContext so downstream code importing from compositor::SharedContext still works.
 pub use fpa_contract::SharedContext;
 
 use crate::direct_signal::{DirectSignal, DirectSignalRegistry};
@@ -57,8 +56,6 @@ pub struct Compositor {
     bus: Arc<DeferredBus>,
     state_machine: StateMachine,
     double_buffer: DoubleBuffer,
-    /// Fallback partitions keyed by the ID of the partition they replace.
-    fallbacks: HashMap<String, Box<dyn Partition>>,
     tick_count: u64,
     /// Accumulated simulation time (sum of all dt values passed to run_tick).
     elapsed_time: f64,
@@ -127,7 +124,6 @@ impl Compositor {
             bus,
             state_machine: StateMachine::new(),
             double_buffer: DoubleBuffer::with_capacity(partition_count),
-            fallbacks: HashMap::new(),
             tick_count: 0,
             elapsed_time: 0.0,
             event_engine: None,
@@ -300,33 +296,6 @@ impl Compositor {
         &self.pending_requests
     }
 
-    /// Register a fallback partition for the given partition ID.
-    ///
-    /// If the primary partition faults during step(), the fallback will be
-    /// activated in its place and the compositor will continue without error.
-    ///
-    /// Returns an error if the fallback's `id()` does not match `partition_id`.
-    pub fn register_fallback(
-        &mut self,
-        partition_id: impl Into<String>,
-        fallback: Box<dyn Partition>,
-    ) -> Result<(), PartitionError> {
-        let partition_id = partition_id.into();
-        if fallback.id() != partition_id {
-            return Err(self.make_error(
-                &partition_id,
-                "register_fallback",
-                format!(
-                    "fallback id '{}' must match partition id '{}'",
-                    fallback.id(),
-                    partition_id,
-                ),
-            ));
-        }
-        self.fallbacks.insert(partition_id, fallback);
-        Ok(())
-    }
-
     /// Get the current execution state.
     pub fn state(&self) -> ExecutionState {
         self.state_machine.state()
@@ -373,15 +342,6 @@ impl Compositor {
         // Initialize all partitions with fault handling
         for partition in &mut self.partitions {
             let result = fault::safe_init(partition.as_mut(), &self.timeout_config);
-            if let Err(e) = result.into_result() {
-                self.state_machine.force_state(ExecutionState::Error);
-                return Err(e.with_layer_depth(self.layer_depth));
-            }
-        }
-
-        // Initialize fallbacks too
-        for fallback in self.fallbacks.values_mut() {
-            let result = fault::safe_init(fallback.as_mut(), &self.timeout_config);
             if let Err(e) = result.into_result() {
                 self.state_machine.force_state(ExecutionState::Error);
                 return Err(e.with_layer_depth(self.layer_depth));
@@ -749,49 +709,21 @@ impl Compositor {
     /// Phase 2 stepping loop, extracted so `run_tick` can guarantee deferred
     /// mode cleanup regardless of fault paths (FPA-014, FPA-011).
     fn run_phase2_stepping(&mut self, dt: f64) -> Result<(), PartitionError> {
-        // For multi-rate partitions, each partition steps `rate` times per outer
-        // tick with `dt / rate` per sub-step. If a partition faults mid-cycle and
-        // a fallback is registered, the fallback completes the remaining sub-steps.
         let mut i = 0;
         while i < self.partitions.len() {
             let partition_id = self.partitions[i].id().to_string();
             let rate = self.rate_config.get_rate(&partition_id);
             let sub_dt = dt / rate as f64;
 
-            for sub in 0..rate {
+            for _sub in 0..rate {
                 let step_result = fault::safe_step(self.partitions[i].as_mut(), sub_dt, &self.timeout_config);
 
                 if let Err(step_err) = step_result.into_result() {
-                    // Check for fallback
-                    if let Some(mut fallback) = self.fallbacks.remove(&partition_id) {
-                        // Step the fallback for the failed sub-step
-                        let fallback_result = fault::safe_step(fallback.as_mut(), sub_dt, &self.timeout_config);
-                        if let Err(fallback_err) = fallback_result.into_result() {
-                            self.state_machine.force_state(ExecutionState::Error);
-                            return Err(fallback_err.with_layer_depth(self.layer_depth));
-                        }
-
-                        // Replace the partition with the fallback
-                        self.partitions[i] = fallback;
-
-                        // Complete remaining sub-steps with the fallback
-                        for _remaining in (sub + 1)..rate {
-                            let r = fault::safe_step(self.partitions[i].as_mut(), sub_dt, &self.timeout_config);
-                            if let Err(e) = r.into_result() {
-                                self.state_machine.force_state(ExecutionState::Error);
-                                return Err(e.with_layer_depth(self.layer_depth));
-                            }
-                        }
-                        break;
-                    }
-
-                    // No fallback - transition to Error and propagate
                     self.state_machine.force_state(ExecutionState::Error);
                     return Err(step_err.with_layer_depth(self.layer_depth));
                 }
             }
 
-            // Collect output after all sub-steps (including fallback's remaining steps)
             let state = fault::safe_contribute_state(self.partitions[i].as_ref(), &self.timeout_config)
                 .map_err(|e| e.with_layer_depth(self.layer_depth))?;
             let envelope = StateContribution {

--- a/crates/fpa-compositor/src/compositor.rs
+++ b/crates/fpa-compositor/src/compositor.rs
@@ -85,6 +85,10 @@ pub struct Compositor {
     last_dump_result: Option<toml::Value>,
     /// Pending load request for Phase 1 processing (FPA-014, FPA-023).
     pending_load: Option<toml::Value>,
+    /// Non-fatal errors from best-effort operations (e.g., despawn shutdown).
+    /// These are detected and enriched per FPA-011 but not propagated because
+    /// the faulting partition is no longer part of the active composition.
+    lifecycle_warnings: Vec<PartitionError>,
     /// Bus reader for transition requests (FPA-006).
     transition_reader: TypedReader<TransitionRequest>,
     /// Bus reader for dump requests (FPA-023).
@@ -139,6 +143,7 @@ impl Compositor {
             pending_dump: false,
             last_dump_result: None,
             pending_load: None,
+            lifecycle_warnings: Vec::new(),
             transition_reader,
             dump_reader,
             load_reader,
@@ -362,6 +367,16 @@ impl Compositor {
     /// Queue a lifecycle operation for processing in the next tick's Phase 1 (FPA-014).
     pub fn request_lifecycle_op(&mut self, op: LifecycleOp) {
         self.pending_lifecycle_ops.push(op);
+    }
+
+    /// Drain and return non-fatal lifecycle warnings (FPA-011).
+    ///
+    /// Lifecycle warnings are errors from best-effort operations like despawn
+    /// shutdown. They are detected and enriched with compositor context but not
+    /// propagated because the faulting partition is no longer part of the active
+    /// composition. Callers should inspect these after each tick.
+    pub fn drain_lifecycle_warnings(&mut self) -> Vec<PartitionError> {
+        std::mem::take(&mut self.lifecycle_warnings)
     }
 
     /// Queue a dump request for processing in the next tick's Phase 1 (FPA-014, FPA-023).
@@ -597,12 +612,14 @@ impl Compositor {
                 LifecycleOp::Despawn(id) => {
                     if let Some(pos) = self.partitions.iter().position(|p| p.id() == id) {
                         let mut removed = self.partitions.remove(pos);
-                        // Shutdown error is intentionally discarded: the partition
-                        // is being removed regardless, similar to Drop semantics.
-                        // A failing shutdown should not prevent despawn or poison
-                        // the compositor — the partition is already gone from the
-                        // active set by this point.
-                        let _ = fault::safe_shutdown(removed.as_mut(), &self.timeout_config);
+                        // Despawn shutdown is best-effort: the partition is already
+                        // removed from the active set, so a failing shutdown should
+                        // not prevent despawn or poison the compositor. The error is
+                        // recorded as a lifecycle warning for observability (FPA-011).
+                        let result = fault::safe_shutdown(removed.as_mut(), &self.timeout_config);
+                        if let Err(e) = result.into_result() {
+                            self.lifecycle_warnings.push(e.with_layer_depth(self.layer_depth));
+                        }
                     }
                 }
             }

--- a/crates/fpa-compositor/src/compositor.rs
+++ b/crates/fpa-compositor/src/compositor.rs
@@ -120,12 +120,13 @@ impl Compositor {
         let transition_reader = bus.subscribe::<TransitionRequest>();
         let dump_reader = bus.subscribe::<DumpRequest>();
         let load_reader = bus.subscribe::<LoadRequest>();
+        let partition_count = partitions.len();
         Self {
             id: "compositor".to_string(),
             partitions,
             bus,
             state_machine: StateMachine::new(),
-            double_buffer: DoubleBuffer::new(),
+            double_buffer: DoubleBuffer::with_capacity(partition_count),
             fallbacks: HashMap::new(),
             tick_count: 0,
             elapsed_time: 0.0,

--- a/crates/fpa-compositor/src/double_buffer.rs
+++ b/crates/fpa-compositor/src/double_buffer.rs
@@ -18,8 +18,6 @@ pub struct DoubleBuffer {
     read: HashMap<String, toml::Value>,
     /// The write buffer accumulates the current tick's outputs.
     write: HashMap<String, toml::Value>,
-    /// Remembered capacity for re-reserving after clear.
-    capacity: usize,
 }
 
 impl DoubleBuffer {
@@ -28,17 +26,17 @@ impl DoubleBuffer {
         Self {
             read: HashMap::new(),
             write: HashMap::new(),
-            capacity: 0,
         }
     }
 
     /// Create a new double buffer with pre-reserved capacity for the expected
-    /// number of partitions. Avoids reallocation as partitions contribute state.
+    /// number of partitions. Avoids reallocation during the first two ticks.
+    /// After that, `HashMap::clear()` retains capacity so no re-reservation
+    /// is needed.
     pub fn with_capacity(partition_count: usize) -> Self {
         Self {
             read: HashMap::with_capacity(partition_count),
             write: HashMap::with_capacity(partition_count),
-            capacity: partition_count,
         }
     }
 
@@ -75,9 +73,6 @@ impl DoubleBuffer {
     pub fn swap(&mut self) {
         std::mem::swap(&mut self.read, &mut self.write);
         self.write.clear();
-        if self.capacity > 0 {
-            self.write.reserve(self.capacity.saturating_sub(self.write.capacity()));
-        }
     }
 }
 

--- a/crates/fpa-compositor/src/double_buffer.rs
+++ b/crates/fpa-compositor/src/double_buffer.rs
@@ -18,6 +18,8 @@ pub struct DoubleBuffer {
     read: HashMap<String, toml::Value>,
     /// The write buffer accumulates the current tick's outputs.
     write: HashMap<String, toml::Value>,
+    /// Remembered capacity for re-reserving after clear.
+    capacity: usize,
 }
 
 impl DoubleBuffer {
@@ -26,6 +28,17 @@ impl DoubleBuffer {
         Self {
             read: HashMap::new(),
             write: HashMap::new(),
+            capacity: 0,
+        }
+    }
+
+    /// Create a new double buffer with pre-reserved capacity for the expected
+    /// number of partitions. Avoids reallocation as partitions contribute state.
+    pub fn with_capacity(partition_count: usize) -> Self {
+        Self {
+            read: HashMap::with_capacity(partition_count),
+            write: HashMap::with_capacity(partition_count),
+            capacity: partition_count,
         }
     }
 
@@ -62,6 +75,9 @@ impl DoubleBuffer {
     pub fn swap(&mut self) {
         std::mem::swap(&mut self.read, &mut self.write);
         self.write.clear();
+        if self.capacity > 0 {
+            self.write.reserve(self.capacity.saturating_sub(self.write.capacity()));
+        }
     }
 }
 

--- a/crates/fpa-compositor/tests/fpa_009_multirate.rs
+++ b/crates/fpa-compositor/tests/fpa_009_multirate.rs
@@ -9,7 +9,7 @@ use fpa_bus::InProcessBus;
 use fpa_compositor::compositor::Compositor;
 use fpa_compositor::multi_rate::RateConfig;
 use fpa_contract::test_support::{Accumulator, Counter};
-use fpa_contract::{Partition, PartitionError, StateContribution};
+use fpa_contract::{Partition, StateContribution};
 
 /// Fast partition (rate 4) steps 4x per tick, slow partition (rate 1) steps 1x.
 #[test]
@@ -161,101 +161,6 @@ fn multi_rate_dt_is_divided_correctly() {
         (total - 2.0).abs() < 1e-12,
         "after 2 ticks with rate=4 and dt=1.0, total should be 2.0 but was {}",
         total,
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Fallback during multi-rate test (Fix 3)
-// ---------------------------------------------------------------------------
-
-/// A partition that fails after N steps. Used to test fallback activation
-/// during a multi-rate sub-step cycle.
-struct FailAfterN {
-    id: String,
-    count: u64,
-    fail_at: u64,
-    initialized: bool,
-}
-
-impl FailAfterN {
-    fn new(id: impl Into<String>, fail_at: u64) -> Self {
-        Self {
-            id: id.into(),
-            count: 0,
-            fail_at,
-            initialized: false,
-        }
-    }
-}
-
-impl Partition for FailAfterN {
-    fn id(&self) -> &str {
-        &self.id
-    }
-
-    fn init(&mut self) -> Result<(), PartitionError> {
-        self.initialized = true;
-        Ok(())
-    }
-
-    fn step(&mut self, _dt: f64) -> Result<(), PartitionError> {
-        if !self.initialized {
-            return Err(PartitionError::new(&self.id, "step", "not initialized"));
-        }
-        self.count += 1;
-        if self.count >= self.fail_at {
-            return Err(PartitionError::new(&self.id, "step", "intentional failure"));
-        }
-        Ok(())
-    }
-
-    fn shutdown(&mut self) -> Result<(), PartitionError> {
-        self.initialized = false;
-        Ok(())
-    }
-
-    fn contribute_state(&self) -> Result<toml::Value, PartitionError> {
-        let mut table = toml::map::Map::new();
-        table.insert("count".to_string(), toml::Value::Integer(self.count as i64));
-        Ok(toml::Value::Table(table))
-    }
-
-    fn load_state(&mut self, _state: toml::Value) -> Result<(), PartitionError> {
-        Ok(())
-    }
-}
-
-/// When a partition fails on sub-step 3 (0-indexed: sub=2) with rate=4,
-/// the fallback should be activated and complete the remaining sub-steps.
-/// Fallback (Counter) should be stepped for: sub 2 (the failed one) + sub 3 = 2 steps.
-#[test]
-fn fallback_completes_remaining_sub_steps() {
-    // FailAfterN with fail_at=3 means it succeeds on steps 1,2 and fails on step 3 (sub=2).
-    let partitions: Vec<Box<dyn Partition>> = vec![
-        Box::new(FailAfterN::new("fragile", 3)),
-    ];
-    let bus = InProcessBus::new("test-bus");
-    let mut compositor = Compositor::new(partitions, Arc::new(bus));
-
-    let mut rate_config = RateConfig::new();
-    rate_config.set_rate("fragile", 4);
-    compositor.set_rate_config(rate_config);
-
-    // Register a Counter as fallback
-    compositor.register_fallback("fragile", Box::new(Counter::new("fragile"))).unwrap();
-
-    compositor.init().unwrap();
-    compositor.run_tick(1.0).unwrap();
-
-    // The fallback Counter should have been stepped for:
-    //   sub 2 (the failed sub-step, fallback takes over) + sub 3 (remaining) = 2 steps
-    let write_buf = compositor.buffer().write_all();
-    let fragile_sc = StateContribution::from_toml(&write_buf["fragile"]).unwrap();
-    let count = fragile_sc.state.as_table().unwrap()
-        .get("count").unwrap().as_integer().unwrap();
-    assert_eq!(
-        count, 2,
-        "fallback should complete remaining sub-steps: 1 for the failed sub-step + 1 remaining = 2"
     );
 }
 

--- a/crates/fpa-compositor/tests/fpa_011.rs
+++ b/crates/fpa-compositor/tests/fpa_011.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use fpa_bus::InProcessBus;
-use fpa_compositor::compositor::Compositor;
+use fpa_compositor::compositor::{Compositor, LifecycleOp};
 use fpa_compositor::state_machine::ExecutionState;
 use fpa_contract::{Partition, PartitionError};
 
@@ -492,5 +492,74 @@ fn error_during_init_includes_operation_context() {
         "error should contain original message: {}",
         err.message
     );
+}
+
+// --- Despawn shutdown warning tests (FPA-011 despawn exception) ---
+
+/// Despawn of a partition that fails shutdown records a lifecycle warning
+/// rather than propagating the error.
+#[test]
+fn despawn_shutdown_error_recorded_as_warning() {
+    let partitions: Vec<Box<dyn Partition>> = vec![
+        Box::new(FailingPartition::new("failer", "shutdown")),
+    ];
+    let bus = InProcessBus::new("test-bus");
+    let mut compositor = Compositor::new(partitions, Arc::new(bus));
+
+    compositor.init().unwrap();
+    compositor.request_lifecycle_op(LifecycleOp::Despawn("failer".to_string()));
+
+    // Tick should succeed — despawn shutdown errors don't propagate
+    let result = compositor.run_tick(1.0);
+    assert!(result.is_ok(), "despawn shutdown failure should not fail the tick");
+
+    // The error should be available as a lifecycle warning
+    let warnings = compositor.drain_lifecycle_warnings();
+    assert_eq!(warnings.len(), 1, "should have one lifecycle warning");
+    assert_eq!(warnings[0].partition_id, "failer");
+    assert_eq!(warnings[0].operation, "shutdown");
+}
+
+/// Despawn of a partition that panics during shutdown records a lifecycle
+/// warning rather than crashing the compositor.
+#[test]
+fn despawn_shutdown_panic_recorded_as_warning() {
+    let partitions: Vec<Box<dyn Partition>> = vec![
+        Box::new(PanickingPartition::on("panicker", "shutdown")),
+    ];
+    let bus = InProcessBus::new("test-bus");
+    let mut compositor = Compositor::new(partitions, Arc::new(bus));
+
+    compositor.init().unwrap();
+    compositor.request_lifecycle_op(LifecycleOp::Despawn("panicker".to_string()));
+
+    let result = compositor.run_tick(1.0);
+    assert!(result.is_ok(), "despawn shutdown panic should not fail the tick");
+
+    let warnings = compositor.drain_lifecycle_warnings();
+    assert_eq!(warnings.len(), 1, "should have one lifecycle warning");
+    assert_eq!(warnings[0].partition_id, "panicker");
+    assert!(
+        warnings[0].message.contains("panic"),
+        "warning should mention panic: {}",
+        warnings[0].message
+    );
+}
+
+/// Successful despawn produces no lifecycle warnings.
+#[test]
+fn despawn_clean_shutdown_no_warnings() {
+    let partitions: Vec<Box<dyn Partition>> = vec![
+        Box::new(fpa_contract::test_support::Counter::new("clean")),
+    ];
+    let bus = InProcessBus::new("test-bus");
+    let mut compositor = Compositor::new(partitions, Arc::new(bus));
+
+    compositor.init().unwrap();
+    compositor.request_lifecycle_op(LifecycleOp::Despawn("clean".to_string()));
+    compositor.run_tick(1.0).unwrap();
+
+    let warnings = compositor.drain_lifecycle_warnings();
+    assert!(warnings.is_empty(), "clean despawn should produce no warnings");
 }
 

--- a/crates/fpa-compositor/tests/fpa_011.rs
+++ b/crates/fpa-compositor/tests/fpa_011.rs
@@ -5,8 +5,7 @@ use std::sync::Arc;
 use fpa_bus::InProcessBus;
 use fpa_compositor::compositor::Compositor;
 use fpa_compositor::state_machine::ExecutionState;
-use fpa_compositor::multi_rate::RateConfig;
-use fpa_contract::{Partition, PartitionError, StateContribution};
+use fpa_contract::{Partition, PartitionError};
 
 // --- Test partition implementations ---
 
@@ -189,53 +188,6 @@ impl Partition for SlowPartition {
     }
 }
 
-/// A simple fallback partition that always succeeds.
-struct FallbackPartition {
-    id: String,
-    step_count: u64,
-}
-
-impl FallbackPartition {
-    fn new(id: &str) -> Self {
-        Self {
-            id: id.to_string(),
-            step_count: 0,
-        }
-    }
-}
-
-impl Partition for FallbackPartition {
-    fn id(&self) -> &str {
-        &self.id
-    }
-
-    fn init(&mut self) -> Result<(), PartitionError> {
-        Ok(())
-    }
-
-    fn step(&mut self, _dt: f64) -> Result<(), PartitionError> {
-        self.step_count += 1;
-        Ok(())
-    }
-
-    fn shutdown(&mut self) -> Result<(), PartitionError> {
-        Ok(())
-    }
-
-    fn contribute_state(&self) -> Result<toml::Value, PartitionError> {
-        let mut table = toml::map::Map::new();
-        table.insert(
-            "fallback_steps".to_string(),
-            toml::Value::Integer(self.step_count as i64),
-        );
-        Ok(toml::Value::Table(table))
-    }
-
-    fn load_state(&mut self, _state: toml::Value) -> Result<(), PartitionError> {
-        Ok(())
-    }
-}
-
 // --- Tests ---
 
 /// Partition returning error from step() -> compositor catches and returns error with context.
@@ -300,56 +252,6 @@ fn error_includes_partition_id_and_operation() {
     assert_eq!(err.operation, "step");
 }
 
-/// With fallback configured: partition faults, fallback activated, compositor continues.
-#[test]
-fn fallback_activated_on_fault() {
-    let partitions: Vec<Box<dyn Partition>> = vec![
-        Box::new(FailingPartition::new("primary", "step")),
-    ];
-    let bus = InProcessBus::new("test-bus");
-    let mut compositor = Compositor::new(partitions, Arc::new(bus));
-
-    // Register a fallback for "primary"
-    compositor.register_fallback("primary", Box::new(FallbackPartition::new("primary"))).unwrap();
-
-    compositor.init().unwrap();
-
-    // Tick should succeed because fallback takes over
-    let result = compositor.run_tick(1.0);
-    assert!(result.is_ok(), "compositor should continue with fallback");
-
-    // The fallback's state should be in the write buffer (wrapped in StateContribution)
-    let state = compositor.buffer().write_all().get("primary").unwrap();
-    let sc = StateContribution::from_toml(state).unwrap();
-    let table = sc.state.as_table().unwrap();
-    assert!(
-        table.contains_key("fallback_steps"),
-        "fallback partition state should be in the buffer"
-    );
-
-    // Subsequent ticks should also work (fallback replaced the primary)
-    let result = compositor.run_tick(1.0);
-    assert!(result.is_ok(), "subsequent ticks should succeed with fallback");
-}
-
-/// Fallback is also initialized during compositor init.
-#[test]
-fn fallback_with_panic_partition() {
-    let partitions: Vec<Box<dyn Partition>> = vec![
-        Box::new(PanickingPartition::new("panicker")),
-    ];
-    let bus = InProcessBus::new("test-bus");
-    let mut compositor = Compositor::new(partitions, Arc::new(bus));
-
-    compositor.register_fallback("panicker", Box::new(FallbackPartition::new("panicker"))).unwrap();
-
-    compositor.init().unwrap();
-
-    // Panicking partition should be caught and fallback activated
-    let result = compositor.run_tick(1.0);
-    assert!(result.is_ok(), "compositor should recover from panic via fallback");
-}
-
 /// Timeout: partition step exceeding 50ms is treated as a fault.
 ///
 /// This test uses a partition that sleeps for 100ms, exceeding the 50ms timeout.
@@ -374,22 +276,6 @@ fn slow_partition_detected_as_timeout() {
         "error should mention timeout: {}",
         err.message
     );
-}
-
-/// Timeout with fallback: slow partition faults, fallback takes over.
-#[test]
-fn slow_partition_with_fallback() {
-    let partitions: Vec<Box<dyn Partition>> = vec![
-        Box::new(SlowPartition::new("slowpoke", 100)),
-    ];
-    let bus = InProcessBus::new("test-bus");
-    let mut compositor = Compositor::new(partitions, Arc::new(bus));
-
-    compositor.register_fallback("slowpoke", Box::new(FallbackPartition::new("slowpoke"))).unwrap();
-
-    compositor.init().unwrap();
-    let result = compositor.run_tick(1.0);
-    assert!(result.is_ok(), "fallback should handle timeout fault");
 }
 
 /// Multiple partitions: one failing, one healthy. Compositor reports the failure.
@@ -589,28 +475,6 @@ fn slow_contribute_state_detected_as_timeout() {
     );
 }
 
-// --- New test: fallback identity mismatch rejected (FPA-011 audit gap) ---
-
-/// Registering a fallback with mismatched id returns an error.
-#[test]
-fn fallback_identity_mismatch_rejected() {
-    let partitions: Vec<Box<dyn Partition>> = vec![
-        Box::new(FallbackPartition::new("primary")),
-    ];
-    let bus = InProcessBus::new("test-bus");
-    let mut compositor = Compositor::new(partitions, Arc::new(bus));
-
-    // Fallback has id "wrong-id" but is registered for "primary"
-    let result = compositor.register_fallback("primary", Box::new(FallbackPartition::new("wrong-id")));
-    assert!(result.is_err(), "registering fallback with mismatched id should return error");
-    let err = result.unwrap_err();
-    assert!(
-        err.message.contains("fallback id"),
-        "error message should mention fallback id mismatch: {}",
-        err.message
-    );
-}
-
 /// Init error includes correct operation context (not "step").
 #[test]
 fn error_during_init_includes_operation_context() {
@@ -630,79 +494,3 @@ fn error_during_init_includes_operation_context() {
     );
 }
 
-// --- Fallback failure during multi-rate remaining sub-steps ---
-
-/// A fallback partition that fails on its second step.
-struct FailOnSecondStep {
-    id: String,
-    count: u64,
-    initialized: bool,
-}
-
-impl FailOnSecondStep {
-    fn new(id: &str) -> Self {
-        Self {
-            id: id.to_string(),
-            count: 0,
-            initialized: false,
-        }
-    }
-}
-
-impl Partition for FailOnSecondStep {
-    fn id(&self) -> &str {
-        &self.id
-    }
-
-    fn init(&mut self) -> Result<(), PartitionError> {
-        self.initialized = true;
-        Ok(())
-    }
-
-    fn step(&mut self, _dt: f64) -> Result<(), PartitionError> {
-        self.count += 1;
-        if self.count >= 2 {
-            return Err(PartitionError::new(&self.id, "step", "fallback failed on second step"));
-        }
-        Ok(())
-    }
-
-    fn shutdown(&mut self) -> Result<(), PartitionError> {
-        Ok(())
-    }
-
-    fn contribute_state(&self) -> Result<toml::Value, PartitionError> {
-        Ok(toml::Value::Table(toml::map::Map::new()))
-    }
-
-    fn load_state(&mut self, _state: toml::Value) -> Result<(), PartitionError> {
-        Ok(())
-    }
-}
-
-/// Multi-rate partition (rate=3) fails on step. Fallback succeeds for the
-/// failed sub-step but fails on the next remaining sub-step. Compositor
-/// transitions to Error.
-#[test]
-fn fallback_failure_during_remaining_substeps() {
-    // FailingPartition fails on every step
-    let partitions: Vec<Box<dyn Partition>> = vec![
-        Box::new(FailingPartition::new("fragile", "step")),
-    ];
-    let bus = InProcessBus::new("test-bus");
-    let mut compositor = Compositor::new(partitions, Arc::new(bus));
-
-    let mut rate_config = RateConfig::new();
-    rate_config.set_rate("fragile", 3);
-    compositor.set_rate_config(rate_config);
-
-    // Fallback that fails on its 2nd step — will succeed for the failed
-    // sub-step but fail on the next remaining sub-step
-    compositor.register_fallback("fragile", Box::new(FailOnSecondStep::new("fragile"))).unwrap();
-
-    compositor.init().unwrap();
-    let result = compositor.run_tick(1.0);
-
-    assert!(result.is_err(), "fallback failure on remaining sub-step should error");
-    assert_eq!(compositor.state(), ExecutionState::Error);
-}

--- a/docs/design/PRINCIPLES_CHECKLIST.md
+++ b/docs/design/PRINCIPLES_CHECKLIST.md
@@ -174,14 +174,13 @@ partition lifecycle calls (init, step, shutdown, contribute_state, load_state).
 **Violation:** A partition panic crashes the compositor. An error from step()
 is silently ignored. A timeout is not detected.
 
-### 5.2 Fallback activation (FPA-011)
-**Principle:** If a fallback is registered for a partition, the compositor
-activates it on fault. The fallback must have the same partition ID. The
-downstream partitions don't know the switch happened.
+### 5.2 Fault propagation (FPA-011)
+**Principle:** When a sub-partition faults, the compositor propagates the error
+to the outer layer. Recovery (fallback, retry) is the responsibility of the
+partition itself or the orchestrator, not the compositor.
 
-**Violation:** A fallback has a different partition ID than the primary. The
-compositor propagates an error despite having a registered fallback. Downstream
-partitions must be modified to work with the fallback.
+**Violation:** The compositor silently absorbs a fault. The compositor attempts
+recovery logic (e.g., activating a fallback) instead of propagating.
 
 ### 5.3 Direct signals (FPA-013)
 **Principle:** Safety-critical signals bypass the relay chain within the

--- a/docs/design/REFERENCE_DOMAINS.md
+++ b/docs/design/REFERENCE_DOMAINS.md
@@ -190,10 +190,11 @@ Atmosphere ──publishes──► AtmosphereState (LatestValue)
   loaded state must propagate correctly through the nested Aerodynamics
   compositor. Validates FPA-023 (load while idle).
 
-- **Fallback partition**: If Aerodynamics panics (numerical instability),
-  the layer 0 compositor activates a SimplifiedAero fallback that uses a
-  reduced model. The fallback completes the remaining sub-steps for that
-  tick. Validates FPA-011 (fault handling with fallback).
+- **Fault propagation**: If Aerodynamics panics (numerical instability),
+  the layer 0 compositor catches the panic, wraps it with diagnostic
+  context (which partition, which layer, which operation), and propagates
+  the error. The orchestrator decides the recovery strategy (e.g.,
+  restarting with a simplified model). Validates FPA-011 (fault handling).
 
 - **Direct signals**: A structural failure detection in Aerodynamics emits
   a direct signal ("structural_failure") that bypasses the relay policy
@@ -349,12 +350,11 @@ DataLogger subscribes to SharedContext (all partition states every tick)
   too generous for a 10ms tick budget. This challenges whether timeout
   constants should be in the spec or configurable.
 
-- **Fallback with identity**: If ControlLaw faults (numerical divergence),
-  a SafeControlLaw fallback activates. The fallback drives actuators to
-  safe positions (valves closed, heaters off). The fallback must have
-  the same partition ID and publish the same ActuatorCommands type.
-  The downstream ActuatorOutput doesn't know the switch happened.
-  Validates FPA-011 (fallback identity requirement).
+- **Fault-triggered safe state**: If ControlLaw faults (numerical
+  divergence), the compositor catches the fault and propagates it. The
+  orchestrator responds by transitioning to a safe state (valves closed,
+  heaters off) — recovery logic lives in the orchestrator, not the
+  compositor. Validates FPA-011 (fault propagation).
 
 - **Direct signals for safety**: SafetyInterlock detects an overpressure
   condition and emits a direct signal ("emergency_shutdown"). This signal
@@ -378,7 +378,7 @@ DataLogger subscribes to SharedContext (all partition states every tick)
 
 - **SafetyInterlock is independent**: SafetyInterlock must not depend on
   ControlLaw's output. It reads SensorReadings directly and makes its
-  own determination. If ControlLaw is in fallback or faulted, safety
+  own determination. If ControlLaw is faulted, safety
   checks continue unaffected. This validates that partitions are truly
   independent — the safety case depends on it.
 
@@ -413,7 +413,7 @@ being tested.
 | Network transport (real) | | **primary** | **primary** | **primary** |
 | Mixed transport per layer | | **primary** | | |
 | State dump/load | validates | **primary** | **primary** | **primary** |
-| Fallback partitions | | **primary** | | **primary** |
+| Fault propagation | | **primary** | | **primary** |
 | Direct signals | | validates | | **primary** |
 | Relay policy | | | | **primary** |
 | Drop-in replacement | **primary** | validates | **primary** | **primary** |

--- a/docs/design/SPECIFICATION.md
+++ b/docs/design/SPECIFICATION.md
@@ -562,8 +562,8 @@ to an alternative sub-partition implementation) without propagating to the outer
 - Pass: A sub-partition emitting a stop request on a layer 1 bus causes
   the compositor to receive the request and emit a corresponding request on the layer 0
   bus; the orchestrator arbitrates the relayed request.
-- Pass: A compositor suppresses an internal request (e.g., by switching to a fallback
-  implementation) without any message appearing on the outer bus.
+- Pass: A compositor suppresses an internal request (e.g., handling it locally)
+  without any message appearing on the outer bus.
 - Pass: A compositor transforms a request before relaying — for example, adding context
   about which sub-partition originated the request.
 - Pass: The relay chain operates correctly through multiple layers: a layer 2 request
@@ -614,22 +614,11 @@ the call to an isolated worker that is discarded after a timeout). The composito
 responsible for enforcing these deadlines for its sub-partitions and for treating a
 timeout exactly as a fault equivalent to an error return or panic. The error shall
 include the compositor's context (which sub-partition faulted, during which operation)
-but the failure itself shall not be silently suppressed. The compositor shall respond to
-a fault as follows: if the fault occurs during steady-state processing — `step()` under
-direct invocation, or the partition's autonomous processing loop under supervisory
-coordination — and a fallback implementation is configured for the faulting sub-partition,
-the compositor activates the fallback, logs the fault and fallback activation, and
-continues processing — the compositor does not return an error to the outer layer in
-this case, but the fault and fallback are recorded in the compositor's diagnostic log.
-In all other cases — faults during `init()`, `shutdown()`, `contribute_state()`, or
-`load_state()`, or any fault when no fallback is configured — the compositor propagates
+but the failure itself shall not be silently suppressed. The compositor shall propagate
 the error to the outer layer by returning an error from its own trait method call, which
-cascades through the compositor chain until the orchestrator receives it. Faults during
-lifecycle transitions (init, shutdown) and state operations (contribute_state, load_state)
-always propagate because a fallback that has not been executing cannot provide coherent
-state or complete a lifecycle transition on behalf of the faulted primary. There shall be
+cascades through the compositor chain until the orchestrator receives it. There shall be
 no fault-specific bus channel or message type; the compositor's error return from its own
-trait call is the propagation mechanism when errors are propagated.
+trait call is the propagation mechanism.
 
 The compositor shall invoke all sub-partition lifecycle methods through fault-handling
 wrappers that catch panics, enforce per-invocation deadlines, and enrich errors with
@@ -638,16 +627,11 @@ without these protections.
 
 When a sub-partition fault is propagated to the outer layer, the compositor shall
 transition its execution state to Error before returning, preventing further lifecycle
-invocations in an inconsistent state. When a fallback is activated, the compositor
-remains in its current execution state.
+invocations in an inconsistent state.
 
 The error returned by the compositor includes context identifying the faulting
 sub-partition's identity, layer depth, and the operation that faulted — both in logged
 output and in the error value returned to the outer layer.
-
-A fallback implementation configured for a sub-partition shall have the same partition
-identity (`id()`) as the primary partition it replaces. The compositor shall reject
-registration of a fallback whose identity does not match the target partition.
 
 **Rationale:** A sub-partition fault means the system's state may be invalid.
 Silently continuing without a failed sub-component produces incorrect results;
@@ -656,24 +640,21 @@ data on reload; running after a failed `init()` means the system was never corre
 assembled. The compositor's role in fault handling is to detect faults — by catching raw panics
 under direct invocation, or by detecting heartbeat failures, error reports, or abnormal
 termination under supervisory coordination — add diagnostic context (which partition,
-which layer, which operation), and either propagate a clean error or activate a
-configured fallback.
-The outer layer sees the compositor's error return (not the raw panic) when errors are
-propagated, preserving encapsulation of the internal structure while ensuring the failure
-is visible. When a fallback is configured, the compositor logs the fault and the fallback
-activation, allowing the system to continue operating in a degraded mode rather than
-halting — this is valuable for systems that prioritize availability or where a
-lower-fidelity alternative can safely substitute for the faulted partition. Domain-specific
-systems may choose to mandate error propagation (fail-fast) as a policy by not
-configuring any fallbacks. A separate fault channel or fault message type would create a
+which layer, which operation), and propagate a clean error.
+The outer layer sees the compositor's error return (not the raw panic),
+preserving encapsulation of the internal structure while ensuring the failure
+is visible. Recovery from faults — such as activating a fallback implementation or
+retrying — is the responsibility of the partition itself or the orchestrator, not the
+compositor. This keeps the compositor's fault handling simple and predictable: detect,
+enrich, propagate. A separate fault channel or fault message type would create a
 parallel communication path with its own transport, relay, and arbitration semantics —
 complexity that is unnecessary because the compositor's call-and-return relationship with
 the outer layer already provides an error propagation path.
 
 **Verification Expectations:**
 - Pass: A sub-partition returning an error from `step()` is caught by the compositor;
-  with no fallback configured, the compositor returns an error from its own `step()`
-  call, which cascades to the orchestrator.
+  the compositor returns an error from its own `step()` call, which cascades to the
+  orchestrator.
 - Pass: A sub-partition panicking during `init()` is caught by the compositor; the
   compositor returns an error from its own `init()` call, preventing the run
   from starting.
@@ -684,11 +665,8 @@ the outer layer already provides an error propagation path.
   sub-partition's identity, layer depth, and the operation that faulted.
 - Pass: The compositor logs the fault with full details regardless of whether the outer
   layer also logs it.
-- Pass: When a fallback is configured for a sub-partition and that sub-partition faults
-  during `step()`, the compositor activates the fallback, logs the fault and fallback
-  activation, and continues processing without returning an error.
 - Fail: A sub-partition fault is silently absorbed by the compositor without logging and
-  without either propagating the error or activating a configured fallback.
+  without propagating the error.
 - Fail: A sub-partition fault propagates as a raw panic or unhandled exception without
   compositor context wrapping.
 - Pass: A compositor constructed with domain-specific timeout values enforces those

--- a/docs/design/SPECIFICATION.md
+++ b/docs/design/SPECIFICATION.md
@@ -615,8 +615,9 @@ responsible for enforcing these deadlines for its sub-partitions and for treatin
 timeout exactly as a fault equivalent to an error return or panic. The error shall
 include the compositor's context (which sub-partition faulted, during which operation)
 but the failure itself shall not be silently suppressed. The compositor shall respond to
-a fault as follows: if the fault occurs during steady-state processing (currently
-`step()`) and a fallback implementation is configured for the faulting sub-partition,
+a fault as follows: if the fault occurs during steady-state processing — `step()` under
+direct invocation, or the partition's autonomous processing loop under supervisory
+coordination — and a fallback implementation is configured for the faulting sub-partition,
 the compositor activates the fallback, logs the fault and fallback activation, and
 continues processing — the compositor does not return an error to the outer layer in
 this case, but the fault and fallback are recorded in the compositor's diagnostic log.

--- a/docs/design/SPECIFICATION.md
+++ b/docs/design/SPECIFICATION.md
@@ -615,15 +615,19 @@ responsible for enforcing these deadlines for its sub-partitions and for treatin
 timeout exactly as a fault equivalent to an error return or panic. The error shall
 include the compositor's context (which sub-partition faulted, during which operation)
 but the failure itself shall not be silently suppressed. The compositor shall respond to
-a fault in one of the following ways, in order of preference: (1) propagate the error to
-the outer layer by returning an error from the compositor's own trait method call, which
-cascades through the compositor chain until the orchestrator receives it; or (2) if a
-fallback implementation is configured for the faulting sub-partition, switch to the
-fallback, log the fault and the fallback activation, and continue processing — the
-compositor does not return an error to the outer layer in this case, but the fault and
-fallback are recorded in the compositor's diagnostic log. If no fallback is configured,
-the compositor shall always propagate the error (option 1). There shall be no
-fault-specific bus channel or message type; the compositor's error return from its own
+a fault as follows: if the fault occurs during steady-state processing (currently
+`step()`) and a fallback implementation is configured for the faulting sub-partition,
+the compositor activates the fallback, logs the fault and fallback activation, and
+continues processing — the compositor does not return an error to the outer layer in
+this case, but the fault and fallback are recorded in the compositor's diagnostic log.
+In all other cases — faults during `init()`, `shutdown()`, `contribute_state()`, or
+`load_state()`, or any fault when no fallback is configured — the compositor propagates
+the error to the outer layer by returning an error from its own trait method call, which
+cascades through the compositor chain until the orchestrator receives it. Faults during
+lifecycle transitions (init, shutdown) and state operations (contribute_state, load_state)
+always propagate because a fallback that has not been executing cannot provide coherent
+state or complete a lifecycle transition on behalf of the faulted primary. There shall be
+no fault-specific bus channel or message type; the compositor's error return from its own
 trait call is the propagation mechanism when errors are propagated.
 
 The compositor shall invoke all sub-partition lifecycle methods through fault-handling

--- a/docs/design/SPECIFICATION.md
+++ b/docs/design/SPECIFICATION.md
@@ -616,9 +616,15 @@ timeout exactly as a fault equivalent to an error return or panic. The error sha
 include the compositor's context (which sub-partition faulted, during which operation)
 but the failure itself shall not be silently suppressed. The compositor shall propagate
 the error to the outer layer by returning an error from its own trait method call, which
-cascades through the compositor chain until the orchestrator receives it. There shall be
-no fault-specific bus channel or message type; the compositor's error return from its own
-trait call is the propagation mechanism.
+cascades through the compositor chain until the orchestrator receives it.
+The one exception is despawn shutdown: when a partition is being removed via a despawn
+lifecycle operation, the partition is already removed from the active composition before
+shutdown is attempted. A shutdown fault during despawn shall be detected and enriched with
+compositor context, but shall not be propagated — it is recorded as a non-fatal lifecycle
+warning available for caller inspection. The despawn proceeds regardless, analogous to
+Drop semantics where cleanup failures are tolerated.
+There shall be no fault-specific bus channel or message type; the compositor's error
+return from its own trait call is the propagation mechanism for faults that are propagated.
 
 The compositor shall invoke all sub-partition lifecycle methods through fault-handling
 wrappers that catch panics, enforce per-invocation deadlines, and enrich errors with

--- a/docs/explanation/applications-of-the-fractal-partition-pattern.md
+++ b/docs/explanation/applications-of-the-fractal-partition-pattern.md
@@ -20,7 +20,7 @@ primitives (contracts, events, configuration, composition, specification, docume
 structure, and testing structure) apply identically at every layer of decomposition.
 
 Five properties define the class of system that results. These are representative, not
-exhaustive — additional emergent properties include configurable fault tolerance
+exhaustive — additional emergent properties include fault detection and propagation
 (FPA-011), safety-critical signal bypass (FPA-013), and declarative event-driven
 behavior (FPA-024 through FPA-029).
 

--- a/docs/explanation/applications-of-the-fractal-partition-pattern.md
+++ b/docs/explanation/applications-of-the-fractal-partition-pattern.md
@@ -16,10 +16,13 @@ The fractal partition pattern is not a domain-specific architecture. It is a str
 discipline that, when applied, produces a system with a specific set of emergent
 properties. These properties are not features that need to be designed and maintained
 independently — they fall out of the pattern's core constraint: the same structural
-primitives (contracts, compositors, events, composition fragments) apply identically at
-every layer of decomposition.
+primitives (contracts, events, configuration, composition, specification, documentation
+structure, and testing structure) apply identically at every layer of decomposition.
 
-Five properties define the class of system that results.
+Five properties define the class of system that results. These are representative, not
+exhaustive — additional emergent properties include configurable fault tolerance
+(FPA-011), safety-critical signal bypass (FPA-013), and declarative event-driven
+behavior (FPA-024 through FPA-029).
 
 ### Distributable execution
 
@@ -44,8 +47,9 @@ conforms to a contract defined at its layer. Any implementation that satisfies t
 contract can be substituted without modifying any peer partition's source code.
 
 The compositor at each layer selects and assembles partition implementations at startup
-based on composition fragments. Changing which implementation is active requires only
-a configuration change. The same mechanism works at every scale: swapping a top-level
+based on composition fragments, then coordinates their lifecycle at runtime — owning
+the layer's bus, arbitrating requests, relaying inter-layer messages, and handling
+faults. Changing which implementation is active requires only a configuration change. The same mechanism works at every scale: swapping a top-level
 subsystem, swapping a sub-component within a subsystem, or swapping a sub-sub-component
 three layers deep.
 

--- a/docs/explanation/bus-performance-and-data-paths.md
+++ b/docs/explanation/bus-performance-and-data-paths.md
@@ -16,8 +16,9 @@ state. The buffer swap at the start of each tick makes the previous tick's
 writes available for reading.
 
 This path is:
-- **Low overhead** — uses a pre-keyed `HashMap<String, toml::Value>`, avoiding
-  per-subscriber cloning and type erasure. No bus involvement.
+- **Low overhead** — uses a capacity-reserved `HashMap<String, toml::Value>`,
+  sized to the partition count at construction to avoid reallocation. No bus
+  involvement, no per-subscriber cloning, no type erasure.
 - **One insert per partition per tick** — the compositor inserts each partition's
   contributed state into the write buffer after stepping. The write buffer is
   cleared on each swap.

--- a/docs/explanation/bus-performance-and-data-paths.md
+++ b/docs/explanation/bus-performance-and-data-paths.md
@@ -16,8 +16,11 @@ state. The buffer swap at the start of each tick makes the previous tick's
 writes available for reading.
 
 This path is:
-- **Direct memory access** — no allocation, no serialization, no bus involvement.
-- **Zero overhead per message** — the compositor writes to a pre-allocated slot.
+- **Low overhead** — uses a pre-keyed `HashMap<String, toml::Value>`, avoiding
+  per-subscriber cloning and type erasure. No bus involvement.
+- **One insert per partition per tick** — the compositor inserts each partition's
+  contributed state into the write buffer after stepping. The write buffer is
+  cleared on each swap.
 - **Deterministic** — step order does not affect results because readers always
   see the previous tick's state.
 

--- a/docs/explanation/bus-performance-and-data-paths.md
+++ b/docs/explanation/bus-performance-and-data-paths.md
@@ -101,17 +101,15 @@ Rust pattern (similar to how `Any` works). The key properties:
    and `bus.subscribe::<M>()` regardless of the underlying transport. No
    transport-specific imports or branches in partition code.
 
-2. **Runtime transport selection** — the compositor can choose transport from
-   configuration at startup. One binary supports all transport modes.
-   *Note: the bus layer supports this today; the compositor currently holds a
-   concrete `InProcessBus` and will be updated to accept `Box<dyn Bus>` in
-   Phase 4 Track M2.*
+2. **Runtime transport selection** — the compositor accepts `Arc<dyn Bus>` at
+   construction, enabling transport selection from configuration at startup.
+   One binary supports all transport modes.
 
 3. **Compile-time type safety** — `BusExt::publish<M>` and
    `BusExt::subscribe<M>` are fully generic. Type mismatches are caught at
    compile time. The type erasure is internal infrastructure, invisible to
    partition authors.
 
-4. **Mixed transports per layer** — once compositors accept `Box<dyn Bus>`
-   (Phase 4 Track M2), different layers can use different transports in the
-   same run (e.g., network at layer 0, in-process at layer 1).
+4. **Mixed transports per layer** — because compositors accept `Arc<dyn Bus>`,
+   different layers can use different transports in the same run (e.g., network
+   at layer 0, in-process at layer 1).

--- a/docs/explanation/communication-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/communication-in-the-fractal-partition-pattern.md
@@ -52,7 +52,7 @@ produce identical results is a correctness constraint, not a convenience.
 ### Inter-partition (horizontal)
 
 Peer partitions at the same layer exchange data through the bus. Partition A publishes
-`PartitionOutput`; Partition B consumes it. Neither knows the other exists. The bus
+its output message type; Partition B consumes it. Neither knows the other exists. The bus
 mediates. Communication is symmetric — any partition can publish, any can subscribe —
 and the compositor at that layer is not involved in routing.
 
@@ -97,10 +97,13 @@ Layer 1 bus (A):  partition-A compositor ↔ sub-A1, sub-A2, sub-A3
 Layer 1 bus (B):  partition-B compositor ↔ sub-B1, sub-B2, sub-B3
 ```
 
-A sub-partition at layer 1 never publishes directly to the layer 0 bus. If its request
-needs to reach the orchestrator, it travels through the compositor relay chain — layer 1
-compositor receives it on the layer 1 bus, decides to relay, and emits on the layer 0
-bus. Each compositor in the chain can intercept, transform, or suppress.
+A sub-partition at layer 1 never publishes directly to the layer 0 bus. Normal requests
+travel through the compositor relay chain — the layer 1 compositor receives a request on
+the layer 1 bus, decides to relay, and emits on the layer 0 bus. Each compositor in the
+chain can intercept, transform, or suppress. Safety-critical signals use the direct
+signal mechanism (FPA-013), which bypasses the relay chain within the declaring contract
+crate's hierarchy — these exist for scenarios where compositor suppression would be
+unsafe.
 
 This scoping preserves encapsulation: the outer layer sees its partitions as opaque
 units. It does not know — and cannot depend on — the internal structure of any partition.
@@ -136,8 +139,8 @@ strategy adaptation. For the complete picture, see
 The two communication roles that are most relevant here operate simultaneously:
 
 1. **Bus owner for its layer.** It creates the bus, connects partitions, publishes
-   shared context (shared state, execution state), and receives requests. In this role it
-   is the layer's orchestrator — the single authority for arbitration and state ownership.
+   shared context (aggregated partition state, execution state, tick metadata), and
+   receives requests. In this role it is the layer's orchestrator — the single authority for arbitration and state ownership.
 
 2. **Partition on the outer layer.** It implements the contract traits of the layer
    above, participates on the outer bus as a peer alongside other partitions, and

--- a/docs/explanation/communication-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/communication-in-the-fractal-partition-pattern.md
@@ -101,9 +101,10 @@ A sub-partition at layer 1 never publishes directly to the layer 0 bus. Normal r
 travel through the compositor relay chain — the layer 1 compositor receives a request on
 the layer 1 bus, decides to relay, and emits on the layer 0 bus. Each compositor in the
 chain can intercept, transform, or suppress. Safety-critical signals use the direct
-signal mechanism (FPA-013), which bypasses the relay chain within the declaring contract
+signal mechanism (FPA-013), which bypasses bus relay policy within the declaring contract
 crate's hierarchy — these exist for scenarios where compositor suppression would be
-unsafe.
+unsafe. Each compositor still filters direct signals against its own signal registry;
+unregistered signal types are dropped at the layer boundary.
 
 This scoping preserves encapsulation: the outer layer sees its partitions as opaque
 units. It does not know — and cannot depend on — the internal structure of any partition.

--- a/docs/explanation/conventions-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/conventions-in-the-fractal-partition-pattern.md
@@ -29,17 +29,20 @@ choices that the pattern's structure supports particularly well.
 
 The compositor at each layer executes each tick as a three-phase lifecycle:
 
-1. **Pre-tick processing:** Process pending lifecycle operations (spawn, despawn, state
-   dump/load), assemble shared context from the previous tick's outputs, publish shared
-   context into the write buffer, and swap the read/write buffers.
+1. **Pre-tick processing:** Check for pending direct signals, process pending lifecycle
+   operations (spawn, despawn), process pending state dump/load requests, and swap the
+   read/write buffers.
 
 2. **Partition stepping:** Each partition reads inter-partition messages from the read
    buffer (previous tick's outputs) and writes its outputs to the write buffer (current
    tick's outputs). No partition observes another partition's current-tick output during
-   this phase.
+   this phase. The compositor checks for direct signals between each partition's step.
+   After all steps complete (the tick barrier), the compositor assembles shared context
+   from the current tick's partition outputs and publishes it on the bus.
 
-3. **Post-tick processing:** Evaluate event conditions, collect outputs, process bus
-   requests, and relay qualified requests to the outer bus.
+3. **Post-tick processing:** Evaluate event conditions against pre-step state, apply
+   triggered actions in TOML declaration order, process bus requests, relay qualified
+   requests to the outer bus, and check for direct signals.
 
 The key mechanism is double-buffering: partitions read from one buffer and write to
 another. The buffers are swapped between ticks. This means every partition sees a

--- a/docs/explanation/events-as-a-fractal-primitive.md
+++ b/docs/explanation/events-as-a-fractal-primitive.md
@@ -135,7 +135,7 @@ A single partition can use actions from multiple contract crates in its event de
 limited to crates in its dependency graph. Partition A might define:
 
 ```toml
-# Action from Partition A's contract crate: inject a fault at scenario time T+60s
+# Action from Partition A's contract crate: inject a fault at logical time T+60s
 [[partition_a.events]]
 trigger = { time = 60.0 }
 action = "inject_fault"
@@ -152,18 +152,22 @@ identifier against the contract crates in scope, finds the declared handler, and
 it. The scenario author does not need to know which contract crate declares an action —
 the schema is the same, and validation catches invalid identifiers at load time.
 
-When multiple events fire in the same tick, ordering follows the event system's
-evaluation semantics. Actions whose handlers emit bus messages interact with the
-arbitration mechanisms already defined (FPA-006 for shared state machine conflicts).
-Actions whose handlers modify internal state take effect in the order the event
-dispatcher evaluates them.
+When multiple events fire in the same tick, the event engine first evaluates all
+conditions against the pre-step state snapshot, collecting the set of fired events.
+Then the compositor applies the triggered actions in TOML declaration order via
+action handlers. This two-step model preserves snapshot semantics: no action's side
+effects are visible to other event conditions in the same evaluation pass. Actions
+whose handlers emit bus messages interact with the arbitration mechanisms already
+defined (FPA-006 for shared state machine conflicts).
 
 ## Time semantics across layers
 
 FPA-025 establishes that time-triggered events use different time references at
-different layers: wall-clock at layer 0, scenario time at layer 1. This applies to all
+different layers: wall-clock at layer 0, logical time at layer 1. Logical time is
+tracked as the cumulative sum of `dt` values passed to the compositor's step invocations,
+not derived from tick count multiplied by the current `dt`. This applies to all
 actions regardless of which contract crate declares them. An action from the system core
-used in a layer 1 event triggers on scenario time. The same action used in a layer 0
+used in a layer 1 event triggers on logical time. The same action used in a layer 0
 event triggers on wall-clock time. The time reference is a property of the layer, not of
 the action or its declaring contract crate.
 

--- a/docs/explanation/execution-strategies-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/execution-strategies-in-the-fractal-partition-pattern.md
@@ -167,7 +167,7 @@ The compositor still:
   monitors partitions through heartbeats, health messages, or connection state. A
   partition that stops publishing, misses a heartbeat deadline, or disconnects is
   considered faulted. The compositor applies the same fault handling policy (FPA-011):
-  propagate the error or activate a fallback.
+  propagate the error to the outer layer.
 
 - **Manages relay.** Inter-layer requests from self-scheduling partitions still flow
   through the bus, and the compositor still has relay authority (FPA-010) over what
@@ -217,10 +217,9 @@ compositor uses mechanisms such as:
   an internal failure. The compositor receives it through normal bus subscription.
 
 The fault handling policy is the same regardless of detection mechanism: the compositor
-logs the fault with diagnostic context (which partition, which layer) and either
-propagates the error to the outer layer or activates a configured fallback (FPA-011).
-The difference is latency — a fault under supervisory coordination may take longer to
-detect than one under direct invocation.
+logs the fault with diagnostic context (which partition, which layer) and propagates
+the error to the outer layer (FPA-011). The difference is latency — a fault under
+supervisory coordination may take longer to detect than one under direct invocation.
 
 ## How core mechanisms adapt
 

--- a/docs/explanation/execution-strategies-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/execution-strategies-in-the-fractal-partition-pattern.md
@@ -83,9 +83,14 @@ Direct invocation is the right choice when:
 The tick lifecycle (FPA-014, defined in FPA-CON-000) is a specific direct-invocation
 strategy that adds a three-phase structure with double-buffered message isolation:
 
-- **Phase 1** assembles shared context, processes lifecycle operations, and swaps buffers.
-- **Phase 2** steps all partitions against the previous cycle's data.
-- **Phase 3** evaluates events, arbitrates requests, and relays messages.
+- **Phase 1** checks direct signals, processes lifecycle operations and dump/load
+  requests, and swaps buffers.
+- **Phase 2** steps all partitions against the previous cycle's data, checking for
+  direct signals between each step. After all steps complete (the tick barrier), the
+  compositor assembles shared context from the current tick's outputs and publishes it
+  on the bus.
+- **Phase 3** evaluates events, arbitrates requests, and relays qualified requests to
+  the outer bus.
 
 The double-buffer ensures that no partition sees another partition's current-cycle output
 during stepping — which makes the result independent of step order and enables safe
@@ -142,15 +147,17 @@ shifts from caller to supervisor.
 The compositor still:
 
 - **Controls lifecycle boundaries.** It tells partitions when they may start processing
-  (after initialization is complete and the bus is connected) and when they must stop
-  (shutdown). No partition begins or ends its processing loop without the compositor's
-  authorization. Note that under supervisory coordination, the synchronous `shutdown()`
-  method is a *signal*, not a *confirmation*: it instructs sub-partitions to stop but
-  does not guarantee they have stopped by the time it returns. The compositor detects
-  actual termination through the same mechanisms it uses for fault detection — heartbeat
-  expiry, connection state, or health messages. For confirmed shutdown with task join,
-  implementations may provide an async shutdown path outside the synchronous Partition
-  trait.
+  and when they must stop. No partition begins or ends its processing loop without the
+  compositor's authorization. Note that under supervisory coordination, the synchronous
+  `init()` and `shutdown()` methods are *signals*, not *confirmations*: `init()` spawns
+  sub-partition tasks but does not guarantee initialization has completed by the time it
+  returns; `shutdown()` instructs sub-partitions to stop but does not guarantee they have
+  stopped. This is inherent to the model — sub-partitions on separate tasks, processes,
+  or nodes cannot be synchronously joined through a synchronous trait method. The
+  compositor detects actual lifecycle completion through the same mechanisms it uses for
+  fault detection — heartbeat expiry, connection state, or health messages. A supervisory
+  compositor should provide async counterparts (e.g., `async_init()`, `async_shutdown()`)
+  that await sub-partition lifecycle completion and propagate faults per FPA-011.
 
 - **Owns the bus.** It publishes shared context, receives requests, and arbitrates shared
   state machines. Partitions interact with each other and with the compositor exclusively
@@ -276,20 +283,19 @@ a freshly computed physics state and a stale one carried forward from a previous
 The difference affects whether the consumer should proceed normally, use interpolation or
 extrapolation, or flag a degraded-data condition.
 
-The compositor shall indicate data freshness as metadata accompanying its output on the
-outer bus (FPA-009). The freshness representation is defined in the contract crate
-alongside the output type. Possible representations include:
+The compositor communicates freshness through the `StateContribution` envelope — a
+wrapper defined in the contract crate that wraps all `contribute_state()` output with
+three fields:
 
-- **A cycle identifier or timestamp** indicating when the data was last computed.
-  Consumers compare against the current cycle to determine staleness.
-- **A freshness flag** (e.g., `Fresh` vs `Stale`) for simple binary decisions.
-- **An age metric** indicating how many outer-layer cycles have elapsed since the data
-  was last updated.
+- **`state`** — the contributed state data itself.
+- **`fresh`** — a boolean indicating whether the data was computed for the current
+  invocation (`true`) or carried forward from a previous cycle (`false`).
+- **`age_ms`** — elapsed time in milliseconds since the data was last computed.
+  Zero when fresh; nonzero when stale.
 
-The contract crate defines which representation is used and what the consumer's
-obligations are when it receives stale data. This is a contract-level concern, not a
-transport concern — freshness metadata travels with the typed message and is part of the
-interface specification.
+The `StateContribution` is the uniform envelope regardless of execution strategy. This
+is a contract-level concern, not a transport concern — freshness metadata travels with
+the typed message and is part of the interface specification.
 
 Under direct invocation with the tick lifecycle, data freshness is trivially `Fresh` for
 every cycle — the compositor computed it synchronously. The freshness metadata may be

--- a/docs/explanation/fractal-partition-pattern.md
+++ b/docs/explanation/fractal-partition-pattern.md
@@ -20,14 +20,18 @@ The defining property — the **layer and partition uniformity principle** — i
 same structural primitives appear at every layer:
 
 - **Contracts** define what a partition must provide and what it may consume.
-- **Compositors** select and assemble partition implementations at startup.
 - **Events** are defined, armed, and triggered using the same schema at every layer.
-- **Composition fragments** configure partition selections using the same TOML format,
-  override semantics, and inheritance rules at every scope.
+- **Configuration** and **composition fragments** configure partition selections using
+  the same TOML format, override semantics, and inheritance rules at every scope.
 - **Specifications** follow the same requirement format with bidirectional traceability
   to the layer above.
 - **Documentation** follows the same Diátaxis structure at every partition.
 - **Testing** follows the same contract test / compositor test structure at every layer.
+
+The compositor at each layer applies these primitives: it selects and assembles
+partition implementations, coordinates their lifecycle at runtime (init, step,
+shutdown), owns the layer's bus, arbitrates requests, relays inter-layer messages,
+and handles faults.
 
 The pattern is called "fractal" because zooming into any partition reveals the same
 structure as the system as a whole, and zooming out reveals that the system itself is a
@@ -90,7 +94,7 @@ from a template.
 
 The event system — time-triggered, condition-triggered, declaratively defined in TOML —
 is the same at every layer. A system-level event that pauses execution at wall-clock T+30s
-uses the same schema as a partition B event that fires a mode transition at scenario time
+uses the same schema as a partition B event that fires a mode transition at logical time
 T+60s, which uses the same schema as a partition A event that halts execution when a
 monitored value exceeds a threshold.
 
@@ -116,7 +120,8 @@ the contract-crate-scoped semantic content.
 ### Documentation and specifications propagate
 
 Each partition maintains a `docs/` directory with the same Diátaxis quadrants (tutorials,
-how-to, reference, explanation, design) and a `SPECIFICATION.md` with the same format.
+how-to, reference, explanation) plus a `design/` directory for specifications and design
+artifacts, and a `SPECIFICATION.md` with the same format.
 A contributor navigating from a system-level partition into one of its sub-partitions
 finds the same documentation layout, the same specification structure, and
 the same traceability conventions. Specifications at each layer nucleate specifications
@@ -253,7 +258,7 @@ A flat plugin system (everything is a plugin at one level) avoids the complexity
 layers but sacrifices the ability to reason about scope and override direction.
 Configuration override semantics depend on knowing which scope is "outer" and which is
 "inner" — a session overrides a scenario, not the reverse. Event time semantics depend
-on knowing which layer you are at — wall-clock at layer 0, scenario time at layer 1.
+on knowing which layer you are at — wall-clock at layer 0, logical time at layer 1.
 The layer concept makes these relationships explicit.
 
 ### Why not enforce a fixed depth

--- a/docs/explanation/fractal-partition-pattern.md
+++ b/docs/explanation/fractal-partition-pattern.md
@@ -75,20 +75,20 @@ rather than being engineered into the system.
 
 ### Configuration collapses to one concept
 
-Sessions, scenarios, entity definitions, and partition presets are all **composition
-fragments** — TOML blocks that select partition implementations at some
-scope. They all support the same `extends` inheritance, the same inline override
-semantics, and the same named-reference resolution. A session is a composition fragment
-at layer 0 that references scenario fragments at layer 1. A scenario is a composition
-fragment that references entity and partition fragments at narrower scopes.
+At every scope — system-level run definitions, partition selections, sub-partition
+presets, initial conditions — the configuration mechanism is the same: **composition
+fragments**. These are TOML blocks that select partition implementations at some scope.
+They all support the same `extends` inheritance, the same inline override semantics, and
+the same named-reference resolution. A composition fragment at layer 0 references
+fragments at layer 1. A fragment at layer 1 references fragments at narrower scopes.
 
 An outer-layer fragment can override any field defined by an inner-layer fragment it
-composes. This means a session file can fully define all scenario content inline —
+composes. This means a layer 0 fragment can fully define all layer 1 content inline —
 useful for simple cases or self-contained examples — or it can reference separate
-scenario files and override only the parameters relevant to a specific run. The same
-mechanism works at every scope: a scenario can override individual sub-model selections
-within a partition preset, an entity definition can override specific initial conditions
-from a template.
+fragments and override only the parameters relevant to a specific run. The same mechanism
+works at every scope: a layer 1 fragment can override individual sub-partition selections
+within a preset, an initial-conditions fragment can override specific values from a
+template.
 
 ### Events work everywhere
 

--- a/docs/explanation/inter-layer-communication.md
+++ b/docs/explanation/inter-layer-communication.md
@@ -70,7 +70,7 @@ distinguished by purpose.
 
 The compositor drives execution by calling trait methods on each partition:
 
-- `init(config)` — initialize with configuration derived from composition fragments
+- `init()` — initialize the partition (configuration is handled at construction time)
 - `step(dt)` — advance one timestep
 - `shutdown()` — clean up resources
 - `contribute_state()` — request a state snapshot contribution
@@ -369,20 +369,30 @@ a bus concern. There is no fault-specific infrastructure.
 Fault handling is one of several compositor roles described in
 [The Compositor in the Fractal Partition Pattern](the-compositor-in-the-fractal-partition-pattern.md).
 
-When a sub-partition faults (detected via a failed call, a missed heartbeat, or a
-disconnection depending on the execution strategy), the compositor decides the response:
+When a sub-partition faults during any lifecycle invocation — including `step()`,
+`init()`, `shutdown()`, `contribute_state()`, and `load_state()` — detected via a
+returned error, a panic, or a timeout, the compositor responds in one of two ways:
 
-- **Emit a stop request.** The compositor emits a stop request on its bus (which may
-  then be relayed to the outer layer through the normal relay chain). The outer layer
-  sees a stop request from the partition, not a raw fault from a sub-partition.
+- **Propagate.** The compositor returns an error from its own trait method call,
+  which cascades through the compositor chain until the orchestrator receives it.
+  The error includes context identifying the faulting sub-partition's identity, layer
+  depth, and the operation that faulted. The compositor transitions to Error state
+  before returning. This is the default when no fallback is configured.
 
-- **Fall back.** If an alternative implementation is available, the compositor might
-  switch to it and continue execution. The outer layer never knows the primary
+- **Fallback.** If a fallback implementation is configured for the faulting
+  sub-partition, the compositor activates it, logs the fault and fallback activation,
+  and continues processing without returning an error. The fallback must have the same
+  partition identity as the primary. The outer layer never knows the primary
   implementation faulted.
 
-- **Log and continue.** For non-fatal errors — a sub-partition reporting a degraded
-  result, a recoverable timeout — the compositor may log the fault and proceed. The
-  outer layer sees no change in behavior.
+There is no "log and continue" option — the compositor must either propagate or
+activate a fallback. Domain-specific systems that want fail-fast behavior simply
+do not configure fallbacks.
+
+The compositor enforces per-invocation elapsed-time deadlines for all lifecycle calls.
+Default values are 50 ms for step/contribute_state and 500 ms for
+init/load_state/shutdown. Domains configure values appropriate to their timing
+constraints. Deadline enforcement cannot be disabled.
 
 ### Why faults are not a bus concern
 
@@ -392,15 +402,10 @@ unnecessary because:
 
 - The compositor already has a direct call-and-return relationship with its
   sub-partitions. It catches errors from `step()` as a normal part of execution.
-- The compositor's response to a fault is a domain decision (stop? fall back? continue?),
-  not a routing decision. It belongs in the compositor's logic, not in bus infrastructure.
-- The outer layer should see the compositor's *decision*, not the raw fault. This is the
-  same encapsulation principle that governs relay authority.
-
-If richer fault context is needed at the outer layer — for diagnostics, logging, or
-operator display — the compositor can include fault details in the payload of its stop
-request or publish a diagnostic message on the outer bus. The mechanism is the existing
-typed message system, not a new fault channel.
+- The compositor's response to a fault is either error propagation via the return path
+  or fallback activation. It belongs in the compositor's logic, not in bus infrastructure.
+- The outer layer should see the compositor's error return, not the raw fault. This is
+  the same encapsulation principle that governs relay authority.
 
 ## Design choices and tradeoffs
 

--- a/docs/explanation/inter-layer-communication.md
+++ b/docs/explanation/inter-layer-communication.md
@@ -180,9 +180,7 @@ it may:
   external stop request).
 
 - **Suppress.** Handle the request internally without relaying. The compositor might
-  respond to a sub-partition failure by switching to a fallback implementation rather
-  than propagating a stop request. The outer layer never knows the internal event
-  occurred.
+  handle a request locally without exposing it to the outer layer.
 
 - **Aggregate.** Collect multiple requests from different sub-partitions within a single
   tick and relay a single consolidated request. This prevents the outer bus from seeing
@@ -376,31 +374,15 @@ Fault handling is one of several compositor roles described in
 
 When a sub-partition faults during any lifecycle invocation — including `step()`,
 `init()`, `shutdown()`, `contribute_state()`, and `load_state()` — detected via a
-returned error, a panic, or a timeout, the compositor responds based on what faulted:
+returned error, a panic, or a timeout, the compositor propagates the error to the outer
+layer by returning an error from its own trait method call, which cascades through the
+compositor chain until the orchestrator receives it. The error includes context
+identifying the faulting sub-partition's identity, layer depth, and the operation that
+faulted. The compositor transitions to Error state before returning.
 
-- **Steady-state processing faults** (`step()` under direct invocation, or the
-  partition's autonomous processing loop under supervisory coordination): If a fallback
-  implementation is configured for the faulting sub-partition, the compositor activates
-  it, logs the fault and fallback activation, and continues processing without returning
-  an error. The fallback must have the same partition identity as the primary. The outer
-  layer never knows the primary implementation faulted. If no fallback is configured, the
-  compositor propagates the error.
-
-- **Lifecycle transition and state operation faults** (`init()`, `shutdown()`,
-  `contribute_state()`, `load_state()`): The compositor always propagates the error,
-  regardless of fallback configuration. A fallback that has not been executing cannot
-  provide coherent state or complete a lifecycle transition on behalf of the faulted
-  primary.
-
-When propagating, the compositor returns an error from its own trait method call,
-which cascades through the compositor chain until the orchestrator receives it.
-The error includes context identifying the faulting sub-partition's identity, layer
-depth, and the operation that faulted. The compositor transitions to Error state
-before returning.
-
-There is no "log and continue" option — the compositor must either propagate or
-activate a fallback. Domain-specific systems that want fail-fast behavior simply
-do not configure fallbacks.
+The compositor's fault handling responsibility is detect, enrich, propagate. Recovery
+from faults — such as activating a fallback implementation or retrying — is the
+responsibility of the partition itself or the orchestrator, not the compositor.
 
 The compositor enforces per-invocation elapsed-time deadlines for all lifecycle calls.
 Default values are 50 ms for step/contribute_state and 500 ms for
@@ -416,7 +398,7 @@ unnecessary because:
 - The compositor already has a direct call-and-return relationship with its
   sub-partitions. It catches errors from `step()` as a normal part of execution.
 - The compositor's response to a fault is either error propagation via the return path
-  or fallback activation. It belongs in the compositor's logic, not in bus infrastructure.
+  It belongs in the compositor's logic, not in bus infrastructure.
 - The outer layer should see the compositor's error return, not the raw fault. This is
   the same encapsulation principle that governs relay authority.
 

--- a/docs/explanation/inter-layer-communication.md
+++ b/docs/explanation/inter-layer-communication.md
@@ -378,11 +378,12 @@ When a sub-partition faults during any lifecycle invocation — including `step(
 `init()`, `shutdown()`, `contribute_state()`, and `load_state()` — detected via a
 returned error, a panic, or a timeout, the compositor responds based on what faulted:
 
-- **Steady-state processing faults** (currently `step()`): If a fallback implementation
-  is configured for the faulting sub-partition, the compositor activates it, logs the
-  fault and fallback activation, and continues processing without returning an error.
-  The fallback must have the same partition identity as the primary. The outer layer
-  never knows the primary implementation faulted. If no fallback is configured, the
+- **Steady-state processing faults** (`step()` under direct invocation, or the
+  partition's autonomous processing loop under supervisory coordination): If a fallback
+  implementation is configured for the faulting sub-partition, the compositor activates
+  it, logs the fault and fallback activation, and continues processing without returning
+  an error. The fallback must have the same partition identity as the primary. The outer
+  layer never knows the primary implementation faulted. If no fallback is configured, the
   compositor propagates the error.
 
 - **Lifecycle transition and state operation faults** (`init()`, `shutdown()`,

--- a/docs/explanation/inter-layer-communication.md
+++ b/docs/explanation/inter-layer-communication.md
@@ -230,21 +230,26 @@ exceeds the cost of breaking layer encapsulation.
 ### How direct signals work
 
 Direct signal types are declared in a contract crate. Any partition within that contract
-crate's hierarchy can emit a declared direct signal. The signal bypasses all intermediate
-bus instances within the hierarchy and reaches the declaring crate's orchestrator
-directly.
+crate's hierarchy can emit a declared direct signal. The signal bypasses the bus relay
+chain — it is not a bus message and is not subject to relay authority (FPA-010). Instead,
+each compositor collects direct signals from its inner compositors and filters them
+against its own signal registry.
 
 ```
 Layer 2 sub-partition emits DirectSignal::EmergencyStop
-  → bypasses layer 2 bus
-  → bypasses layer 1 bus
-  → reaches system orchestrator directly
+  → layer 2 compositor collects signal (bypasses layer 2 bus)
+  → layer 1 compositor collects signal, filters against its registry
+  → layer 0 orchestrator collects signal, filters against its registry
   → orchestrator applies emergency response
 ```
 
-The mechanism for bypass is implementation-specific — it might be a separate channel, a
-shared atomic, or a direct callback registered during initialization. The key property
-is that no compositor in the chain can intercept or suppress it.
+Each compositor maintains a signal registry defining which direct signal types are
+recognized at its layer. When collecting signals from inner compositors, the outer
+compositor filters against its own registry — only signals whose type identifier is
+registered at the outer layer propagate. Unregistered signals are silently dropped at
+the boundary. The key property is that signals bypass bus relay authority: no compositor
+can suppress a registered signal through relay policy the way it can suppress a bus
+message.
 
 ### Direct signals are hierarchy-scoped
 

--- a/docs/explanation/inter-layer-communication.md
+++ b/docs/explanation/inter-layer-communication.md
@@ -380,9 +380,12 @@ compositor chain until the orchestrator receives it. The error includes context
 identifying the faulting sub-partition's identity, layer depth, and the operation that
 faulted. The compositor transitions to Error state before returning.
 
-The compositor's fault handling responsibility is detect, enrich, propagate. Recovery
-from faults — such as activating a fallback implementation or retrying — is the
-responsibility of the partition itself or the orchestrator, not the compositor.
+The compositor's fault handling responsibility is detect, enrich, propagate. The one
+exception is despawn shutdown: when a partition is being removed, a shutdown fault is
+recorded as a non-fatal warning rather than propagated, because the partition is already
+gone from the active composition (analogous to Drop semantics). Recovery from faults —
+such as activating a fallback implementation or retrying — is the responsibility of the
+partition itself or the orchestrator, not the compositor.
 
 The compositor enforces per-invocation elapsed-time deadlines for all lifecycle calls.
 Default values are 50 ms for step/contribute_state and 500 ms for

--- a/docs/explanation/inter-layer-communication.md
+++ b/docs/explanation/inter-layer-communication.md
@@ -376,19 +376,26 @@ Fault handling is one of several compositor roles described in
 
 When a sub-partition faults during any lifecycle invocation — including `step()`,
 `init()`, `shutdown()`, `contribute_state()`, and `load_state()` — detected via a
-returned error, a panic, or a timeout, the compositor responds in one of two ways:
+returned error, a panic, or a timeout, the compositor responds based on what faulted:
 
-- **Propagate.** The compositor returns an error from its own trait method call,
-  which cascades through the compositor chain until the orchestrator receives it.
-  The error includes context identifying the faulting sub-partition's identity, layer
-  depth, and the operation that faulted. The compositor transitions to Error state
-  before returning. This is the default when no fallback is configured.
+- **Steady-state processing faults** (currently `step()`): If a fallback implementation
+  is configured for the faulting sub-partition, the compositor activates it, logs the
+  fault and fallback activation, and continues processing without returning an error.
+  The fallback must have the same partition identity as the primary. The outer layer
+  never knows the primary implementation faulted. If no fallback is configured, the
+  compositor propagates the error.
 
-- **Fallback.** If a fallback implementation is configured for the faulting
-  sub-partition, the compositor activates it, logs the fault and fallback activation,
-  and continues processing without returning an error. The fallback must have the same
-  partition identity as the primary. The outer layer never knows the primary
-  implementation faulted.
+- **Lifecycle transition and state operation faults** (`init()`, `shutdown()`,
+  `contribute_state()`, `load_state()`): The compositor always propagates the error,
+  regardless of fallback configuration. A fallback that has not been executing cannot
+  provide coherent state or complete a lifecycle transition on behalf of the faulted
+  primary.
+
+When propagating, the compositor returns an error from its own trait method call,
+which cascades through the compositor chain until the orchestrator receives it.
+The error includes context identifying the faulting sub-partition's identity, layer
+depth, and the operation that faulted. The compositor transitions to Error state
+before returning.
 
 There is no "log and continue" option — the compositor must either propagate or
 activate a fallback. Domain-specific systems that want fail-fast behavior simply

--- a/docs/explanation/inter-layer-communication.md
+++ b/docs/explanation/inter-layer-communication.md
@@ -400,7 +400,7 @@ unnecessary because:
 
 - The compositor already has a direct call-and-return relationship with its
   sub-partitions. It catches errors from `step()` as a normal part of execution.
-- The compositor's response to a fault is either error propagation via the return path
+- The compositor's response to a fault is error propagation via the return path.
   It belongs in the compositor's logic, not in bus infrastructure.
 - The outer layer should see the compositor's error return, not the raw fault. This is
   the same encapsulation principle that governs relay authority.

--- a/docs/explanation/inter-partition-communication.md
+++ b/docs/explanation/inter-partition-communication.md
@@ -54,9 +54,9 @@ from each other.
 ## Typed messages
 
 All data crossing partition boundaries travels as instances of named, versioned message
-types declared in the contract crate. `PartitionOutput`, `CommandMessage`, `EnvState`,
-`SharedContext` — these are concrete structs with documented fields, statically checked
-by the compiler.
+types declared in the contract crate. `SharedContext`, `TransitionRequest`,
+`DumpRequest`, `LoadRequest` — these are concrete structs with documented fields,
+statically checked by the compiler.
 
 The alternative — untyped byte buffers, serialized JSON, or dynamic payloads — trades
 compile-time safety for flexibility that the system doesn't need. Partitions exchange a
@@ -121,8 +121,8 @@ The bus-mediated request pattern has several properties:
 
 - **Conflict resolution.** When two partitions request conflicting transitions in the
   same tick — one requests pause, another requests stop — the owner applies a
-  deterministic priority rule (stop beats pause beats resume) rather than letting the
-  outcome depend on message ordering.
+  deterministic, transport-independent priority rule defined by the domain-specific
+  specification, rather than letting the outcome depend on message ordering.
 
 - **Partition ignorance.** A partition emitting a request doesn't need to know who the
   owner is, how many other partitions exist, or what other requests are in flight. It
@@ -136,8 +136,9 @@ are defined in the contract crate, not in any partition. One owner holds the
 authoritative value. All other partitions observe it as read-only. Transitions happen
 through bus requests.
 
-The execution state machine (Idle → Running → Paused → Stopped) is the primary instance
-of this pattern at layer 0. But the pattern is general. At layer 1, sub-partitions
+The execution state machine (Uninitialized → Initializing → Running → Paused →
+ShuttingDown → Terminated, with Error reachable from multiple states) is the primary
+instance of this pattern at layer 0. But the pattern is general. At layer 1, sub-partitions
 within partition B might coordinate around a domain-specific phase state machine
 (phase 1 → phase 2 → phase 3 → phase 4) defined in partition B's contract module. The
 mechanism is identical: type in the contract module, single owner, bus-mediated
@@ -175,9 +176,9 @@ configuration interface.
 
 Multi-entity systems require each entity's partitions to be aware of peer entities.
 Rather than having partitions query each other — which would create lateral coupling —
-the system publishes an aggregated `SharedContext` each tick containing the
-`PartitionOutput` of all active entities. Every partition receives the same
-`SharedContext` through the bus.
+the compositor publishes an aggregated `SharedContext` each tick containing the
+aggregated partition state, tick metadata, and execution state. Every partition receives
+the same `SharedContext` through the bus.
 
 This is a broadcast pattern: one publisher (the orchestrator), many consumers, no
 consumer-specific channels. A partition B plugin coordinating with peers reads their

--- a/docs/explanation/test-reference-data-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/test-reference-data-in-the-fractal-partition-pattern.md
@@ -90,9 +90,10 @@ independent of any specific partition's numerical output:
 
 - **Message delivery**: partition A sends a message on channel X, partition B receives
   it in the same tick (or next tick, per the contract).
-- **Conservation**: structural invariants are preserved — e.g., the number of
-  partitions is conserved across ticks, the write buffer has exactly one entry per
-  partition. Domain-level conservation (energy, mass, momentum) across partition
+- **Conservation**: structural invariants are preserved — e.g., the write buffer has
+  exactly one entry per active partition, the set of active partition IDs is stable
+  across ticks when no lifecycle ops occur. Domain-level conservation (energy, mass,
+  momentum) across partition
   boundaries is a future concern that reference domains would exercise.
 - **Ordering**: execution order respects the declared dependency graph — partition A runs
   before partition B, which runs before partition C.

--- a/docs/explanation/test-reference-data-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/test-reference-data-in-the-fractal-partition-pattern.md
@@ -90,8 +90,10 @@ independent of any specific partition's numerical output:
 
 - **Message delivery**: partition A sends a message on channel X, partition B receives
   it in the same tick (or next tick, per the contract).
-- **Conservation**: the sum of energy (or mass, or momentum) across all partition
-  boundaries is preserved within stated tolerances.
+- **Conservation**: structural invariants are preserved — e.g., the number of
+  partitions is conserved across ticks, the write buffer has exactly one entry per
+  partition. Domain-level conservation (energy, mass, momentum) across partition
+  boundaries is a future concern that reference domains would exercise.
 - **Ordering**: execution order respects the declared dependency graph — partition A runs
   before partition B, which runs before partition C.
 - **Visibility**: state that one partition publishes is visible to its declared consumers

--- a/docs/explanation/testing-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/testing-in-the-fractal-partition-pattern.md
@@ -103,8 +103,8 @@ traceability.
 
 ### System tests are relative to system scope
 
-The specification (FPA-SRS-000) states that system tests exist only at layer 0, and
-this is true — but layer 0 is relative. Every system that applies the fractal partition
+The conventions document (FPA-CON-000) defines system tests (FPA-034) as tests that
+exercise the full stack within a system's scope boundary, and layer 0 is relative. Every system that applies the fractal partition
 pattern has its own layer 0, and therefore its own system tests.
 
 Consider a system called "inner-system" whose system tests exercise the full processing

--- a/docs/explanation/testing-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/testing-in-the-fractal-partition-pattern.md
@@ -104,8 +104,9 @@ traceability.
 ### System tests are relative to system scope
 
 The conventions document (FPA-CON-000) defines system tests (FPA-034) as tests that
-exercise the full stack within a system's scope boundary, and layer 0 is relative. Every system that applies the fractal partition
-pattern has its own layer 0, and therefore its own system tests.
+exercise the full stack within a system's scope boundary, and layer 0 is relative.
+Every system that applies the fractal partition pattern has its own layer 0, and
+therefore its own system tests.
 
 Consider a system called "inner-system" whose system tests exercise the full processing
 stack: configuration in, results out. They trace to inner-system's FPA requirements.

--- a/docs/explanation/the-compositor-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/the-compositor-in-the-fractal-partition-pattern.md
@@ -29,16 +29,19 @@ at one scale participates as a peer at the next scale up.
 
 ## Role 1: Assembly
 
-At startup, the compositor reads composition fragments (FPA-020, FPA-021) to determine
-which partition implementations to instantiate at its layer. A layer 0 orchestrator reads
-a session fragment and selects top-level partitions. A layer 1 compositor reads a scenario
-fragment and selects sub-partitions. The mechanism is the same at every layer — named
-composition fragments with inheritance and override semantics.
+At startup, the compositor reads composition fragments (FPA-019, FPA-020, FPA-021) to
+determine which partition implementations to instantiate at its layer. A layer 0
+orchestrator reads a layer 0 composition fragment and selects top-level partitions. A
+layer 1 compositor reads a layer 1 composition fragment and selects sub-partitions. The
+mechanism is the same at every layer — composition fragments with inheritance and
+override semantics. Assembly uses the standard composition entry point (FPA-015), which
+accepts a composition fragment, a partition registry mapping implementation names to
+constructors, and a bus instance.
 
 The compositor resolves `extends` chains, applies inline overrides, and instantiates the
-selected implementations. It connects each partition to the layer's bus and verifies that
-all contract dependencies are satisfied. Assembly is complete before any runtime
-processing begins.
+selected implementations via registry lookup. It connects each partition to the layer's
+bus and verifies that all contract dependencies are satisfied. Assembly is complete before
+any runtime processing begins.
 
 This role is the least controversial — most component frameworks have an assembly phase.
 What distinguishes FPA is that the assembly mechanism is uniform across layers: the same
@@ -102,10 +105,11 @@ coordination variable, trigger a phase change — it emits a typed request on th
 compositor receives the request, evaluates it against the state machine's transition
 rules, and applies or rejects it.
 
-Single-owner arbitration prevents conflicting mutations. If two partitions request
-conflicting transitions in the same processing cycle, the compositor resolves the
-conflict using a deterministic priority rule defined in the contract crate. All requests
-and resolutions are logged, providing an audit trail.
+Single-owner arbitration prevents conflicting mutations. The compositor evaluates each
+request against the state machine's transition rules and applies or rejects it. When
+multiple requests arrive in the same processing cycle, they are processed sequentially
+using a deterministic, transport-independent rule defined by the domain-specific
+specification. All requests and resolutions are logged, providing an audit trail.
 
 The arbitration pattern is the same at every layer. At layer 0, the orchestrator
 arbitrates system-level state machines. At layer 1, a partition's compositor arbitrates

--- a/docs/explanation/the-compositor-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/the-compositor-in-the-fractal-partition-pattern.md
@@ -146,15 +146,21 @@ When a sub-partition faults during any lifecycle invocation — `init()`, `step(
 or timing out, the compositor catches the fault, adds diagnostic context (which partition,
 which layer, which operation), and responds (FPA-011).
 
-The response is:
+The response depends on what faulted:
 
-1. **Fallback.** If a fallback implementation is configured for the faulting partition,
-   the compositor activates it, logs the fault and fallback activation, and continues
-   processing. The fallback must have the same partition identity as the primary. The
-   outer layer does not see an error, but the fault is recorded.
-2. **Propagate.** If no fallback is configured, the compositor returns an error from its
-   own lifecycle method call, cascading through the compositor chain to the orchestrator.
-   The compositor transitions to Error state before returning.
+- **Steady-state processing faults** (currently `step()`): If a fallback implementation
+  is configured for the faulting partition, the compositor activates it, logs the fault
+  and fallback activation, and continues processing. The fallback must have the same
+  partition identity as the primary. The outer layer does not see an error, but the fault
+  is recorded. If no fallback is configured, the compositor propagates the error.
+- **All other faults** (`init()`, `shutdown()`, `contribute_state()`, `load_state()`):
+  The compositor always propagates the error to the outer layer, regardless of fallback
+  configuration. A fallback that has not been executing cannot provide coherent state or
+  complete a lifecycle transition on behalf of the faulted primary.
+
+When propagating, the compositor returns an error from its own lifecycle method call,
+cascading through the compositor chain to the orchestrator. The compositor transitions
+to Error state before returning.
 
 The compositor enforces per-invocation elapsed-time deadlines for all lifecycle calls.
 Default values are 50 ms for step/contribute_state and 500 ms for

--- a/docs/explanation/the-compositor-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/the-compositor-in-the-fractal-partition-pattern.md
@@ -128,8 +128,7 @@ relay gateway (FPA-010). It has full authority over what crosses its layer bound
 - **Transform.** Modify the request before relaying — add context, change the request
   type, convert an internal warning into an external stop request.
 - **Suppress.** Handle the request internally without forwarding. The compositor might
-  respond to a sub-partition failure by switching to a fallback rather than propagating
-  the failure outward.
+  handle a request locally without exposing it to the outer layer.
 - **Aggregate.** Combine multiple requests from a single processing cycle into one
   consolidated message on the outer bus.
 
@@ -146,23 +145,9 @@ When a sub-partition faults during any lifecycle invocation — `init()`, `step(
 or timing out, the compositor catches the fault, adds diagnostic context (which partition,
 which layer, which operation), and responds (FPA-011).
 
-The response depends on what faulted:
-
-- **Steady-state processing faults** (`step()` under direct invocation, or the
-  partition's autonomous processing loop under supervisory coordination): If a fallback
-  implementation is configured for the faulting partition, the compositor activates it,
-  logs the fault and fallback activation, and continues processing. The fallback must
-  have the same partition identity as the primary. The outer layer does not see an error,
-  but the fault is recorded. If no fallback is configured, the compositor propagates the
-  error.
-- **All other faults** (`init()`, `shutdown()`, `contribute_state()`, `load_state()`):
-  The compositor always propagates the error to the outer layer, regardless of fallback
-  configuration. A fallback that has not been executing cannot provide coherent state or
-  complete a lifecycle transition on behalf of the faulted primary.
-
-When propagating, the compositor returns an error from its own lifecycle method call,
-cascading through the compositor chain to the orchestrator. The compositor transitions
-to Error state before returning.
+The compositor propagates the error to the outer layer by returning an error from its own
+lifecycle method call, cascading through the compositor chain to the orchestrator. The
+compositor transitions to Error state before returning.
 
 The compositor enforces per-invocation elapsed-time deadlines for all lifecycle calls.
 Default values are 50 ms for step/contribute_state and 500 ms for
@@ -176,8 +161,8 @@ connection state, or error messages on the bus. The fault handling policy is the
 regardless of detection mechanism — only the detection latency differs.
 
 The compositor never silently absorbs a fault. Every fault is logged with full diagnostic
-context, and the compositor either activates a configured fallback or propagates the error.
-There is no third option.
+context and propagated. Recovery from faults — such as activating a fallback or retrying —
+is the responsibility of the partition itself or the orchestrator.
 
 ## Role 7: Partition on the outer layer
 
@@ -242,8 +227,8 @@ decides whether to relay it outward. The arbitration result (applied, rejected, 
 pending) may influence the relay decision.
 
 **Fault handling interacts with lifecycle and relay.** A fault detected during a lifecycle
-invocation may trigger a fallback (lifecycle), an error propagation (relay to the outer
-layer), or both. The compositor's fault handling policy determines which path is taken.
+invocation triggers error propagation to the outer layer. The compositor detects, enriches,
+and propagates — it does not attempt recovery.
 
 **The outer-partition role constrains all other roles.** The compositor must satisfy its
 outer contract. Its lifecycle coordination, bus management, arbitration, relay, and fault

--- a/docs/explanation/the-compositor-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/the-compositor-in-the-fractal-partition-pattern.md
@@ -160,9 +160,13 @@ supervisory coordination, the compositor detects faults through heartbeat monito
 connection state, or error messages on the bus. The fault handling policy is the same
 regardless of detection mechanism — only the detection latency differs.
 
-The compositor never silently absorbs a fault. Every fault is logged with full diagnostic
-context and propagated. Recovery from faults — such as activating a fallback or retrying —
-is the responsibility of the partition itself or the orchestrator.
+The compositor never silently absorbs a fault. Every fault is detected and enriched with
+full diagnostic context. Faults during active lifecycle operations are propagated to the
+outer layer. The one exception is despawn shutdown: when a partition is being removed, a
+shutdown fault is recorded as a non-fatal warning rather than propagated, because the
+partition is already gone from the active composition. Recovery from faults — such as
+activating a fallback or retrying — is the responsibility of the partition itself or the
+orchestrator.
 
 ## Role 7: Partition on the outer layer
 

--- a/docs/explanation/the-compositor-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/the-compositor-in-the-fractal-partition-pattern.md
@@ -137,27 +137,34 @@ for the full relay chain treatment.
 
 ## Role 6: Fault handler
 
-When a sub-partition faults — by returning an error, panicking, timing out, missing a
-heartbeat, or disconnecting — the compositor catches the fault, adds diagnostic context
-(which partition, which layer, which operation), and responds (FPA-011).
+When a sub-partition faults during any lifecycle invocation — `init()`, `step()`,
+`shutdown()`, `contribute_state()`, or `load_state()` — by returning an error, panicking,
+or timing out, the compositor catches the fault, adds diagnostic context (which partition,
+which layer, which operation), and responds (FPA-011).
 
-The response follows a priority order:
+The response is:
 
-1. **Propagate.** Return an error from the compositor's own lifecycle method, cascading
-   through the compositor chain to the orchestrator. This is the default when no fallback
-   is configured.
-2. **Fallback.** If a fallback implementation is configured for the faulting partition,
-   switch to it, log the fault and fallback activation, and continue processing. The
+1. **Fallback.** If a fallback implementation is configured for the faulting partition,
+   the compositor activates it, logs the fault and fallback activation, and continues
+   processing. The fallback must have the same partition identity as the primary. The
    outer layer does not see an error, but the fault is recorded.
+2. **Propagate.** If no fallback is configured, the compositor returns an error from its
+   own lifecycle method call, cascading through the compositor chain to the orchestrator.
+   The compositor transitions to Error state before returning.
+
+The compositor enforces per-invocation elapsed-time deadlines for all lifecycle calls.
+Default values are 50 ms for step/contribute_state and 500 ms for
+init/load_state/shutdown; domains configure values appropriate to their constraints.
+Deadline enforcement cannot be disabled.
 
 The fault detection mechanism varies by execution strategy. Under direct invocation, the
-compositor catches errors and panics from the call itself, and enforces per-invocation
-timeouts. Under supervisory coordination, the compositor detects faults through heartbeat
-monitoring, connection state, or error messages on the bus. The fault handling policy is
-the same regardless of detection mechanism — only the detection latency differs.
+compositor catches errors and panics from the call itself and enforces deadlines. Under
+supervisory coordination, the compositor detects faults through heartbeat monitoring,
+connection state, or error messages on the bus. The fault handling policy is the same
+regardless of detection mechanism — only the detection latency differs.
 
 The compositor never silently absorbs a fault. Every fault is logged with full diagnostic
-context, and the compositor either propagates it or activates a configured fallback.
+context, and the compositor either activates a configured fallback or propagates the error.
 There is no third option.
 
 ## Role 7: Partition on the outer layer
@@ -192,15 +199,15 @@ compositor at the boundary translates.
 
 When the inner strategy produces output asynchronously, the compositor's output may
 reflect previously computed state rather than state computed for the current invocation.
-The compositor communicates this through **freshness metadata** — information accompanying
-its output that indicates whether the data was freshly computed or carried forward. The
-freshness representation (cycle identifier, timestamp, staleness flag, age metric) is
-defined in the contract crate alongside the output type.
+The compositor communicates this through the **StateContribution** envelope — a wrapper
+defined in the contract crate that wraps all `contribute_state()` output with freshness
+metadata: the `state` itself, a `fresh` flag indicating whether it was computed for the
+current invocation, and an `age_ms` field indicating how stale the data is.
 
 Consumers read the freshness metadata and decide how to handle stale data — proceed
 normally, interpolate, or flag a degraded condition. Under uniform lock-step execution,
-freshness is trivially "fresh" every cycle and the metadata may be omitted or always set
-to fresh. It becomes meaningful at layer boundaries where strategies diverge.
+freshness is trivially "fresh" every cycle. It becomes meaningful at layer boundaries
+where strategies diverge.
 
 See
 [Execution Strategies in the Fractal Partition Pattern](execution-strategies-in-the-fractal-partition-pattern.md)

--- a/docs/explanation/the-compositor-in-the-fractal-partition-pattern.md
+++ b/docs/explanation/the-compositor-in-the-fractal-partition-pattern.md
@@ -148,11 +148,13 @@ which layer, which operation), and responds (FPA-011).
 
 The response depends on what faulted:
 
-- **Steady-state processing faults** (currently `step()`): If a fallback implementation
-  is configured for the faulting partition, the compositor activates it, logs the fault
-  and fallback activation, and continues processing. The fallback must have the same
-  partition identity as the primary. The outer layer does not see an error, but the fault
-  is recorded. If no fallback is configured, the compositor propagates the error.
+- **Steady-state processing faults** (`step()` under direct invocation, or the
+  partition's autonomous processing loop under supervisory coordination): If a fallback
+  implementation is configured for the faulting partition, the compositor activates it,
+  logs the fault and fallback activation, and continues processing. The fallback must
+  have the same partition identity as the primary. The outer layer does not see an error,
+  but the fault is recorded. If no fallback is configured, the compositor propagates the
+  error.
 - **All other faults** (`init()`, `shutdown()`, `contribute_state()`, `load_state()`):
   The compositor always propagates the error to the outer layer, regardless of fallback
   configuration. A fallback that has not been executing cannot provide coherent state or

--- a/docs/explanation/tick-lifecycle-and-synchronization.md
+++ b/docs/explanation/tick-lifecycle-and-synchronization.md
@@ -46,12 +46,8 @@ Under the tick lifecycle convention, every compositor — at every layer — exe
  │  │ Check direct signals                    │  │
  │  │ Process lifecycle operations            │  │
  │  │ Process dump/load requests              │  │
- │  │ Assemble shared context from tick N-1   │  │
- │  │ Publish shared context, execution       │  │
- │  │   state (into write buffer)             │  │
  │  │ Swap read/write buffers                 │  │
- │  │   new read buffer = tick N-1 outputs +  │  │
- │  │     shared context + execution state    │  │
+ │  │   new read buffer = tick N-1 outputs    │  │
  │  │   new write buffer = cleared for tick N │  │
  │  └─────────────────────────────────────────┘  │
  │                                               │
@@ -59,18 +55,20 @@ Under the tick lifecycle convention, every compositor — at every layer — exe
  │  ┌─────────────────────────────────────────┐  │
  │  │ for each partition:                     │  │
  │  │   read from read buffer                 │  │
- │  │     (tick N-1 outputs, shared context,  │  │
- │  │      execution state)                   │  │
+ │  │     (tick N-1 partition outputs)        │  │
  │  │   step(dt)                              │  │
  │  │   write to write buffer                 │  │
  │  │   check direct signals                  │  │
+ │  │ ── tick barrier ──                      │  │
+ │  │ Assemble shared context from tick N     │  │
+ │  │   partition outputs (write buffer)      │  │
+ │  │ Publish shared context on bus           │  │
  │  └─────────────────────────────────────────┘  │
  │                                               │
  │  Phase 3: Post-tick                           │
  │  ┌─────────────────────────────────────────┐  │
  │  │ Evaluate events (against pre-step state)│  │
  │  │ Apply triggered actions (TOML order)    │  │
- │  │ Collect tick N outputs                  │  │
  │  │ Arbitrate bus requests                  │  │
  │  │ Relay to outer bus                      │  │
  │  │ Check direct signals                    │  │
@@ -99,18 +97,9 @@ some partitions would see the new entity and others would not.
 state snapshots capture temporally consistent data — every partition's contribution
 comes from the same completed tick.
 
-**Shared context assembly** collects all partition outputs from tick N-1 and publishes
-them as an atomic aggregate. The tick barrier ensures that no partition's output is
-missing or stale.
-
-**Shared context and execution state** are published into the buffer that will become
-the read buffer for tick N after the upcoming buffer swap — the buffer that partitions
-will read from during Phase 2. This ensures these values are stable and visible to all
-partitions throughout Phase 2.
-
 **Buffer swap** transitions the double-buffer: after the swap, the read buffer for
-tick N contains tick N-1 partition outputs plus the shared context and execution state
-published above, and a fresh write buffer is prepared for tick N outputs.
+tick N contains tick N-1 partition outputs, and a fresh write buffer is prepared for
+tick N outputs.
 
 ### Phase 2: Partition Stepping — Intra-tick Message Isolation
 
@@ -179,6 +168,15 @@ all steps complete, giving a worst-case latency of the longest partition's step 
 In both cases the compositor checks signals while it has exclusive control — not while
 partition state is being mutated — avoiding reentrancy hazards.
 
+**Shared context assembly** occurs after the tick barrier — once all partition `step()`
+calls have completed. The compositor assembles shared context from the current tick's
+partition outputs (the write buffer) and publishes it on the bus along with the current
+execution state. SharedContext is a typed bus message, not a double-buffer entry:
+partitions and external consumers subscribe to it through the same bus mechanism used
+for all other typed messages. Publishing after the tick barrier ensures shared context
+reflects the complete, consistent state of all partitions after tick N — no partition's
+output is missing or partial.
+
 ### Phase 3: Post-tick Processing
 
 Phase 3 runs after all partitions have completed their step for tick N.
@@ -221,8 +219,10 @@ runtime role (FPA-009) with precise timing semantics. It integrates with:
   Each compositor at each layer runs its own tick lifecycle on its own bus.
 - **Direct signals** (FPA-013): Polling between partition steps gives signals
   sub-tick latency while avoiding reentrancy hazards.
-- **Recursive state contribution** (FPA-012): The tick boundary in Phase 1 ensures
+- **Recursive state contribution** (FPA-012): The tick boundary ensures
   that `contribute_state()` calls observe consistent, completed state.
+  Dump requests processed in Phase 1 invoke `contribute_state()` using
+  post-tick-N-1 state.
 - **Compositor fault handling** (FPA-011): Faults during any lifecycle invocation in any
   phase are caught by the compositor, wrapped with diagnostic context, and propagated
   upward — the compositor does not silently absorb failures.

--- a/docs/explanation/tick-lifecycle-and-synchronization.md
+++ b/docs/explanation/tick-lifecycle-and-synchronization.md
@@ -59,6 +59,8 @@ Under the tick lifecycle convention, every compositor — at every layer — exe
  │  │   step(dt)                              │  │
  │  │   write to write buffer                 │  │
  │  │   check direct signals                  │  │
+ │  │ end for                                 │  │
+ │  │                                         │  │
  │  │ ── tick barrier ──                      │  │
  │  │ Assemble shared context from tick N     │  │
  │  │   partition outputs (write buffer)      │  │
@@ -224,8 +226,10 @@ runtime role (FPA-009) with precise timing semantics. It integrates with:
   Dump requests processed in Phase 1 invoke `contribute_state()` using
   post-tick-N-1 state.
 - **Compositor fault handling** (FPA-011): Faults during any lifecycle invocation in any
-  phase are caught by the compositor, wrapped with diagnostic context, and propagated
-  upward — the compositor does not silently absorb failures.
+  phase are caught by the compositor and wrapped with diagnostic context. For faults
+  during steady-state processing (`step()`), a configured fallback is activated if
+  available; all other faults propagate upward. The compositor does not silently absorb
+  failures.
 - **Transport abstraction** (FPA-004): The tick lifecycle is one mechanism that
   makes the transport independence guarantee enforceable for tick-based systems —
   by isolating partitions from each other's current-tick outputs, the result

--- a/docs/explanation/tick-lifecycle-and-synchronization.md
+++ b/docs/explanation/tick-lifecycle-and-synchronization.md
@@ -227,8 +227,9 @@ runtime role (FPA-009) with precise timing semantics. It integrates with:
   post-tick-N-1 state.
 - **Compositor fault handling** (FPA-011): Faults during any lifecycle invocation in any
   phase are caught by the compositor and wrapped with diagnostic context. For faults
-  during steady-state processing (`step()`), a configured fallback is activated if
-  available; all other faults propagate upward. The compositor does not silently absorb
+  during steady-state processing (`step()` under direct invocation, or the autonomous
+  processing loop under supervisory coordination), a configured fallback is activated
+  if available; all other faults propagate upward. The compositor does not silently absorb
   failures.
 - **Transport abstraction** (FPA-004): The tick lifecycle is one mechanism that
   makes the transport independence guarantee enforceable for tick-based systems —

--- a/docs/explanation/tick-lifecycle-and-synchronization.md
+++ b/docs/explanation/tick-lifecycle-and-synchronization.md
@@ -226,11 +226,8 @@ runtime role (FPA-009) with precise timing semantics. It integrates with:
   Dump requests processed in Phase 1 invoke `contribute_state()` using
   post-tick-N-1 state.
 - **Compositor fault handling** (FPA-011): Faults during any lifecycle invocation in any
-  phase are caught by the compositor and wrapped with diagnostic context. For faults
-  during steady-state processing (`step()` under direct invocation, or the autonomous
-  processing loop under supervisory coordination), a configured fallback is activated
-  if available; all other faults propagate upward. The compositor does not silently absorb
-  failures.
+  phase are caught by the compositor, wrapped with diagnostic context, and propagated
+  upward. The compositor does not silently absorb failures.
 - **Transport abstraction** (FPA-004): The tick lifecycle is one mechanism that
   makes the transport independence guarantee enforceable for tick-based systems —
   by isolating partitions from each other's current-tick outputs, the result


### PR DESCRIPTION
## Summary

This PR updates documentation across the fractal partition pattern specification to clarify and refine several core compositor behaviors, particularly around lifecycle management, fault handling, state contribution, and direct signal mechanics. The changes reflect a more precise understanding of how compositors coordinate partition lifecycles and handle errors.

## Key Changes

- **Lifecycle method signatures**: Updated `init()` to take no parameters (configuration handled at construction time) and clarified that `init()` and `shutdown()` under supervisory coordination are signals, not confirmations, with actual completion detected through heartbeat/health mechanisms.

- **Fault handling model**: Simplified FPA-011 to propagation-only semantics. The compositor's fault handling responsibility is strictly detect, enrich, propagate — no recovery logic. Compositor-level fallback activation has been removed entirely; recovery from faults (fallback implementations, retries) is the responsibility of the partition itself or the orchestrator. This eliminates significant complexity for a pattern better handled at other layers. Added mandatory per-invocation elapsed-time deadline enforcement (50ms for step/contribute_state, 500ms for init/load_state/shutdown) that cannot be disabled.

- **Despawn shutdown exception**: Despawn shutdown faults were silently discarded. Now they are detected, enriched with compositor context, and recorded as non-fatal lifecycle warnings available via `drain_lifecycle_warnings()`. The spec carves out despawn shutdown as an explicit exception to the propagation rule — the partition is already removed from the active composition, so propagation would be wrong, but silent discard violates FPA-011.

- **State contribution envelope**: Introduced `StateContribution` as the uniform wrapper for all `contribute_state()` output, containing three fields: `state` (the data), `fresh` (boolean indicating current-cycle computation), and `age_ms` (staleness metric). This replaces the previous flexible "freshness metadata" concept with a concrete, contract-defined structure.

- **Direct signal mechanism**: Clarified that direct signals bypass the bus relay chain but are subject to per-layer signal registry filtering. Each compositor maintains a registry of recognized signal types; unregistered signals are silently dropped at layer boundaries. This preserves the safety property (signals cannot be suppressed by relay policy) while enabling scoped signal propagation.

- **Tick lifecycle phases**: Reorganized phase descriptions to clarify that shared context assembly occurs *after* the tick barrier (once all partition steps complete), not before. Fixed Phase 2 diagram to show tick barrier and shared context assembly outside the per-partition loop. Shared context is published as a typed bus message, not a double-buffer entry.

- **Assembly mechanism**: Expanded documentation of the assembly role to explicitly describe the standard composition entry point (FPA-015), partition registry lookup, and bus connection as part of the assembly process.

- **Event evaluation semantics**: Clarified that event conditions are evaluated against pre-step state snapshots, with all fired events collected before actions are applied in TOML declaration order. This preserves snapshot semantics across multiple events in the same tick.

- **Time reference terminology**: Changed "scenario time" to "logical time" (cumulative sum of `dt` values) for consistency and clarity about how time is tracked across layers.

- **Bus transport abstraction**: Updated notes to reflect that compositors now accept `Arc<dyn Bus>` at construction, enabling runtime transport selection and mixed transports per layer.

- **Double buffer capacity reservation**: Added `with_capacity()` constructor to `DoubleBuffer` that pre-sizes the HashMap to the partition count, avoiding per-tick reallocation. Updated bus performance explainer to accurately describe the optimization.

- **Fallback removal**: Removed compositor-level fallback from the lock-step compositor (`fallbacks` field, `register_fallback()`, fallback init loop, fallback activation in stepping). Removed 6 fallback tests and 3 helper types. Simplified FPA-011 across the spec, all explainers, reference domains, and principles checklist. See issue #10 for rationale.

## Notable Implementation Details

- Fault handling enforces a strict propagation-only model: detect the fault, enrich with diagnostic context, propagate to the outer layer. Recovery is not a compositor concern.
- Despawn shutdown is the one exception: faults are detected and recorded as lifecycle warnings, not propagated, because the partition is already gone from the active composition.
- Deadline enforcement is mandatory and cannot be disabled, providing deterministic timeout behavior across all execution strategies.
- The `StateContribution` envelope is the uniform interface regardless of execution strategy, making freshness metadata a contract-level concern rather than a transport concern.
- Direct signal filtering at layer boundaries enables safety-critical signals to bypass relay suppression while still respecting layer scoping through registry-based filtering.